### PR TITLE
pybsn-repl --env-token/-e to allow loading token from environment variable + fix unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.3.2 - 04-01-2020
+### Added
+- `pybsn-repl` - optional parameter `env-token` allows specifying
+the name of an environment variable to read the session token from.
+
 ## 0.3.1 - 07-01-2019
 ### Added
 - `pybsn.connect` - optional parameter `session_headers` allows specifying

--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -26,15 +26,26 @@ import argparse
 import logging
 import textwrap
 import re
+import os
 from traitlets.config.loader import Config
 from IPython.terminal.ipapp import TerminalIPythonApp
 from IPython.core.inputtransformer import StatelessInputTransformer
 from IPython.core.magic import Magics, magics_class, line_magic
 
+
+def env_var(value):
+    if value not in os.environ:
+        raise argparse.ArgumentTypeError("'%s' is not an environment variable" % value)
+    return os.environ[value]
+
+
 parser = argparse.ArgumentParser(description=__doc__)
 
 parser.add_argument('--host', '-H', type=str, default="127.0.0.1", help="Controller IP/Hostname to connect to")
-parser.add_argument('--token', '-t', type=str, help="Session/Token to use")
+token_source = parser.add_mutually_exclusive_group()
+token_source.add_argument('--token', '-t', type=str, help="Session/Token to use")
+token_source.add_argument('--env-token', '-e', type=env_var, dest='token',
+                          help="Environment variable of session/token to use")
 parser.add_argument('--user', '-u', type=str, default="admin", help="Username")
 parser.add_argument('--password', '-p', type=str, default="adminadmin", help="Password")
 parser.add_argument('--verbose', '-v', action="count", default=0, help="Debug output")

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -381,19 +381,20 @@ def _attempt_login(session, url, username, password):
         If successful, stores the resulting cookie in the provided requests objects.
         Raises a requests exception (e.g., requests.exceptions.HTTPError) on error.
     """
-    request = requests.Request(method="HEAD", url = url + "/api/v2/schema/controller/root/core/aaa/session/login" )
+    request = requests.Request(method="HEAD", url=url + "/api/v2/schema/controller/root/core/aaa/session/login")
     response = logged_request(session, request)
     if response.status_code == 200:
         return _attempt_modern_login(session, url, username, password)
     else:
         return _attempt_legacy_login(session, url, username, password)
 
+
 def _attempt_legacy_login(session, url, username, password):
-    auth_data = json.dumps({ 'user': username, 'password': password })
+    auth_data = json.dumps({ 'user': username, 'password': password})
     path = "/api/v1/auth/login"
     request = requests.Request(method="POST", url=url + path, data=auth_data)
     response = logged_request(session, request)
-    if response.status_code == 200: # OK
+    if response.status_code == 200:  # OK
         # Fix up cookie path
         for cookie in session.cookies:
             if cookie.path == "/auth":
@@ -401,6 +402,7 @@ def _attempt_legacy_login(session, url, username, password):
         return url
     else:
         response.raise_for_status()
+
 
 def _attempt_modern_login(session, url, username, password):
     auth_data = json.dumps({ 'user': username, 'password': password })

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -2,7 +2,10 @@ import json
 import logging
 import re
 from string import Template
-import urllib
+try:
+    from urlparse import urlparse  # python2
+except:
+    from urllib.parse import urlparse  # python3
 
 import requests
 
@@ -411,7 +414,7 @@ def _attempt_modern_login(session, url, username, password):
     response = logged_request(session, request)
     if response.status_code == 200:
         json_ = response.json()
-        session_cookie = requests.cookies.create_cookie(name="session_cookie", value=json_["session-cookie"], domain=urllib.parse.urlparse(url).hostname, path="/api")
+        session_cookie = requests.cookies.create_cookie(name="session_cookie", value=json_["session-cookie"], domain=urlparse(url).hostname, path="/api")
         session.cookies.set_cookie(session_cookie)
         return url
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 setup(name='pybsn',
-    version='0.3.1',
+    version='0.3.2',
     description="pybsn is a python interface to Big Switch Networks' products",
     url='https://github.com/floodlight/pybsn',
-    author='Jason Parraga, Rich Lane, Andreas Wundsam',
-    author_email='Sovietaced@gmail.com, Rich.Lane@bigswitch.com, Andreas.Wundsam@bigswitch.com',
+    author='Jason Parraga, Rich Lane, Andreas Wundsam, Andre Kutzleb',
+    author_email='Sovietaced@gmail.com, Rich.Lane@bigswitch.com, Andreas.Wundsam@bigswitch.com, Andre.Kutzleb@arista.com',
     license='ECLIPSE',
     packages=['pybsn'],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,14 @@ setup(name='pybsn',
     description="pybsn is a python interface to Big Switch Networks' products",
     url='https://github.com/floodlight/pybsn',
     author='Jason Parraga, Rich Lane, Andreas Wundsam, Andre Kutzleb',
-    author_email='Sovietaced@gmail.com, Rich.Lane@bigswitch.com, Andreas.Wundsam@bigswitch.com, Andre.Kutzleb@arista.com',
+    author_email='Sovietaced@gmail.com, Rich.Lane@bigswitch.com, Andreas.Wundsam@arista.com, Andre.Kutzleb@arista.com',
     license='ECLIPSE',
     packages=['pybsn'],
     zip_safe=False,
     install_requires=[
-    "requests >= 2.3.0"
+        "requests >= 2.3.0",
+        "IPython >= 7.9",
+        "traitlets >= 4.3.3",
     ],
     tests_require=[
         "responses >= 0.10.6"

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -11,6 +11,7 @@ import responses
 
 my_dir = os.path.dirname(__file__)
 
+
 class TestBigDbClient(unittest.TestCase):
     def setUp(self):
         self.client = pybsn.connect("http://127.0.0.1:8080")

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -72,7 +72,7 @@ class TestBigDbClient(unittest.TestCase):
 
     @responses.activate
     def test_close_no_auth(self):
-        self.client.close
+        self.client.close()
 
     @responses.activate
     def test_connect_wrong_pw(self):


### PR DESCRIPTION
Allow loading a session token from the environment using `--env-token`, which is mutually exclusive from `--token` (b0a5ae6a41f5dc46eadb0d3a811583db0542a481)

4c2f75f...9bc8b04 fixes the fallout and adds tests for #29, and does some minor refactoring/improvements to other test.

---

```
user@host:~/pybsn/bin$ foo=bar ./pybsn-repl --env-token=foo
Namespace(host='127.0.0.1', password='adminadmin', token='bar', user='admin', verbose=0)

user@host:~/pybsn/bin$ foo=bar ./pybsn-repl --token=foo
Namespace(host='127.0.0.1', password='adminadmin', token='foo', user='admin', verbose=0)
```

~~Tests are curreently failing due to https://github.com/bigswitch/pybsn/pull/29#issuecomment-608665172~~ Fixed those failing tests as part of this PR.
 