### PR TITLE
BSC-14339: pybsn-repl; optionally execute a non-interactive command with -c

### DIFF
--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -49,6 +49,7 @@ token_source.add_argument('--env-token', '-e', type=env_var, dest='token',
 parser.add_argument('--user', '-u', type=str, default="admin", help="Username")
 parser.add_argument('--password', '-p', type=str, default="adminadmin", help="Password")
 parser.add_argument('--verbose', '-v', action="count", default=0, help="Debug output")
+parser.add_argument('--command', '-c', help="Command to execute")
 
 args = parser.parse_args()
 logging.basicConfig(level=logging.DEBUG if args.verbose > 0 else logging.INFO)
@@ -146,8 +147,11 @@ config.TerminalInteractiveShell.confirm_exit = False
 user_ns = dict(ctrl=ctrl, root=ctrl.root, show_schema=show_schema)
 
 app = TerminalIPythonApp(config=config)
-app.initialize(argv=[])
+app.interact = not args.command
+app.initialize(argv = [])
 app.shell.push(user_ns, interactive=False)
 app.shell.input_transformers_cleanup.append(line_transform)
 app.shell.register_magics(BsnMagics(app.shell))
+if args.command:
+    app.shell.run_cell(args.command)
 app.start()


### PR DESCRIPTION
Interactive validation (we don't have unit tests for pybsn-repl yet):
```bash
andi@andreaswundsam:~/dev/andi-tools/bsc-14218  [master>] $ pybsn-repl -H 10.2.1.27 -c 'root.core.aaa.local_user.match(user_name="admin").full_name.put("fred")'
Out[1]: <Response [204]>

andi@andreaswundsam:~/dev/andi-tools/bsc-14218  [master>] $ pybsn-repl -H 10.2.1.27 -c 'print(root.core.aaa.local_user.match(user_name="admin").full_name())'
['fred']
```