### PR TITLE
Properly select twine repo based on user input

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -25,8 +25,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
 
-    - run: |
-        echo "${{ github.event.inputs.twineRepo }}"
+    - name: Choose Twine Repository
+      run: |
+        if [ -z "${{ github.event.inputs.twineRepo }}" ]; then
+            echo TWINE_REPO=pypi >> $GITHUB_ENV
+        else
+            echo TWINE_REPO="${{ github.event.inputs.twineRepo }}" >> $GITHUB_ENV
+        fi
 
     - name: Build and publish
       env:
@@ -34,4 +39,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload --repository "${{ github.event.inputs.twineRepo }}" dist/*
+        twine upload --repository "${{ env.TWINE_REPO }}" dist/*


### PR DESCRIPTION
Follow-up to #35.

As-is, `release-pypi` would not be able to release to `PyPi` when triggered by a tag push, because in that context the user-provided variable `github.event.inputs.twineRepo` would be missing. This change introduces an environment variable `TWINE_REPO` that is set in any case, and which is overwritten with the user input, if present.

![image](https://user-images.githubusercontent.com/19155548/106825737-54b1b200-663a-11eb-9bdb-778d54a654c8.png)
(Note: intentionally failed job in the end due to auth)
