### PR TITLE
BSC-14372: Drop python2/nosetest, modernize infastructure, prep 0.4.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,9 +25,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage
+        python -m pip install coverage flake8
         python -m pip install -r requirements.txt
 
-    - name: Run tests with Coverage
-      run: |
-        cd test && nosetests --with-coverage
+    - name: Enforce Github editor 127 character width
+      run: flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --statistics
+
+    - name: Check syntax errors and undefined names
+      run: flake8 ./pybsn/ ./bin/* --count --select=E9,F63,F7,F82 --show-source --statistics
+
+    - name: Run unit tests with coverage
+      # Exclude dependencies in coverage report with --omit
+      run: coverage run --omit */*-packages/* -m unittest discover -v
+
+    - name: Check Coverage Results
+        # Could gate here to prevent pass under certain coverage %
+      run: coverage report

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os-version: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9] # remove 2.7 once the support is dropped
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
+
+# Generated Coverage reports
+*.coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.4.0 - UNRELEASED
+### Removed
+- python 2 support has been removed.
+- nosetest has been removed as dependency.
+
 ## 0.3.3 - 2021-02-03
 ### Removed
 - `pybsn.bcf`. Pybsn contained a a very partial "Porcelain" API layer called pybsn.bcf. It

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to this repository
+
+### Ready to make a change? Fork the repo
+
+Fork using GitHub Desktop:
+
+- [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop) will guide you through setting up Desktop.
+- Once Desktop is set up, you can use it to [fork the repo](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/cloning-and-forking-repositories-from-github-desktop)!
+
+Fork using the command line:
+
+- [Fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository) so that you can make your changes without affecting the original project until you're ready to merge them.
+
+Fork with [GitHub Codespaces](https://github.com/features/codespaces):
+
+- [Fork, edit, and preview](https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/creating-a-codespace) using [GitHub Codespaces](https://github.com/features/codespaces) without having to install and run the project locally.
+
+### Make your update:
+Make your changes to the file(s) you'd like to update. 
+Test your changes by running all tests with `python -m unittest discover`.
+
+### Open a pull request
+When you're done making changes and you'd like to propose them for review, use the [pull request template](#pull-request-template) to open your PR (pull request).
+
+### Submit your PR & get it reviewed
+- Once you submit your PR, others from the pybsn community will review it with you.
+- Automatic tests and code analysis will be run against your contribution. Make sure your code passes these checks. 
+- After that, we may have questions, check back on your PR to keep up with the conversation.
+
+### Your PR is merged!
+Congratulations! The pybsn community thanks you. :sparkles:
+
+### How to release a new version of pybsn
+To help release a new version of pybsn, there are two github actions. They are triggered when a new tag is pushed to the repository. Each tag push is considered a release, and each of the two actions will attempt to create a release using the version found in [setup.py](https://github.com/bigswitch/pybsn/blob/master/setup.py). The name of the tag does not matter from a technical perspective, but should match the version in the `setup.py` file. 
+1. [release-github.yml](https://github.com/bigswitch/pybsn/blob/master/.github/workflows/release-github.yml) 
+Creates a release on github. The release description is the message of the last commit of the release branch (`master`).
+2. [release-pypi.yml](https://github.com/bigswitch/pybsn/blob/master/.github/workflows/release-pypi.yml) 
+Creates a release on [PyPi](https://pypi.org/project/pybsn/).
+
+### Attribution
+This `CONTRIBUTING.md` has been adapted from [Github Docs](https://github.com/github/docs/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,26 +1,23 @@
 # pybsn
 pybsn is a python interface to [Big Switch Network](http://bigswitch.com) products
 
-[![Build Status](https://travis-ci.org/bigswitch/pybsn.svg)](https://travis-ci.org/bigswitch/pybsn)
 [![PyPI version](https://badge.fury.io/py/pybsn.svg)](https://pypi.python.org/pypi/pybsn/)
 
 ## Installation
 
 ```bash
-pip install pybsn
-# ... or ...
 pip3 install pybsn
 ```
-pybsn is compatible with python 2.7+ and python 3.
+As of version 0.4.0, pybsn is only compatible with python 3.5 or newer.
 
 ---
 ## PyBSN Repl - Interactive Shell
 
-`pybsn-repl` is a powerful, interactive shell for the REST API. It is based on and requires python3 and ipython 7.0. (**Note**: The pybsn library works with python 2.7 and python 3, the repl program requires python 3!)
+`pybsn-repl` is a powerful, interactive shell for the REST API. It is based on and requires python3.5 or newer and ipython 7.9 or newer.
 
 ### Installing Python3 on Mac
 
-[Homebrew](https://brew.sh/) is a recommended option to install python3 on mac
+[Homebrew](https://brew.sh/) is a recommended option to install python3 on mac.
 
 After you install homebrew, install python3 with
 
@@ -32,13 +29,12 @@ brew install python
 ```bash
 pip3 install ipython
 ```
-* Note: make sure you use the `pip` module associated with `python3`. Often, it is available as `pip3`; otherwise you may want to try `python3 -m pip install ...` instead.
 
 ### Running pybsn-repl
 ```bash
 ./bin/pybsn-repl -H <controller_host> -u <user> -p <passwd>
 ```
-**Note:** `pybsn-repl` requires `pybsn` to be available; you can either install it from `pip` (see above); or use it directly from the source by prefixing the
+**Note:** `pybsn-repl` requires `pybsn` to be available; you can either install it from `pip3` (see above); or use it directly from the source by prefixing the
 command with `PYTHONPATH=<dir>`, e.g.,
 
 ```bash

--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -60,6 +60,7 @@ if args.token:
 else:
     ctrl = pybsn.connect(host=args.host, username=args.user, password=args.password)
 
+
 def line_transform(lines):
     def convert(line):
         if line.endswith('#'):
@@ -67,7 +68,8 @@ def line_transform(lines):
         else:
             return line
 
-    return [ convert(l.strip()) + "\n" for l in lines ]
+    return [convert(li.strip()) + "\n" for li in lines]
+
 
 @magics_class
 class BsnMagics(Magics):
@@ -75,9 +77,10 @@ class BsnMagics(Magics):
     def help(self, s):
         print(__doc__.strip())
 
+
 def show_schema(root, max_depth=1, verbose=True):
     def pretty_type(node):
-        if not 'typeSchemaNode' in node:
+        if 'typeSchemaNode' not in node:
             return node['leafType'].lower()
 
         t = node['typeSchemaNode']
@@ -130,7 +133,7 @@ def show_schema(root, max_depth=1, verbose=True):
         elif node['nodeType'] == 'RPC':
             output(name, "(rpc)", description)
             if max_depth is not None and depth < max_depth:
-                for name, item in ( ("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
+                for name, item in (("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
                     if item in node:
                         traverse(node[item], depth+1, name, max_depth=None)
                     else:
@@ -140,6 +143,7 @@ def show_schema(root, max_depth=1, verbose=True):
 
     traverse(root.schema(), name=root._path, max_depth=max_depth)
 
+
 config = Config()
 config.TerminalInteractiveShell.banner1 = "pybsn REPL - Run %help for help"
 config.TerminalInteractiveShell.confirm_exit = False
@@ -148,7 +152,7 @@ user_ns = dict(ctrl=ctrl, root=ctrl.root, show_schema=show_schema)
 
 app = TerminalIPythonApp(config=config)
 app.interact = not args.command
-app.initialize(argv = [])
+app.initialize(argv=[])
 app.shell.push(user_ns, interactive=False)
 app.shell.input_transformers_cleanup.append(line_transform)
 app.shell.register_magics(BsnMagics(app.shell))

--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -19,8 +19,6 @@ Examples:
     # Get info for a specific switch
     root.core.switch.match(name="leaf0a").get()
 """
-from __future__ import print_function
-
 import pybsn
 import argparse
 import logging
@@ -29,9 +27,7 @@ import re
 import os
 from traitlets.config.loader import Config
 from IPython.terminal.ipapp import TerminalIPythonApp
-from IPython.core.inputtransformer import StatelessInputTransformer
 from IPython.core.magic import Magics, magics_class, line_magic
-
 
 def env_var(value):
     if value not in os.environ:

--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -29,6 +29,7 @@ from traitlets.config.loader import Config
 from IPython.terminal.ipapp import TerminalIPythonApp
 from IPython.core.magic import Magics, magics_class, line_magic
 
+
 def env_var(value):
     if value not in os.environ:
         raise argparse.ArgumentTypeError("'%s' is not an environment variable" % value)

--- a/bin/pybsn-schema
+++ b/bin/pybsn-schema
@@ -15,8 +15,6 @@ easily, you'll want to use the 'path' and '--max-depth' options. For example:
 
 This shows 2 levels of schema starting from the path "controller.core.switch".
 """
-from __future__ import print_function
-
 import pybsn
 import argparse
 import json

--- a/bin/pybsn-schema
+++ b/bin/pybsn-schema
@@ -40,7 +40,7 @@ args = parser.parse_args()
 
 
 def pretty_type(node):
-    if not 'typeSchemaNode' in node:
+    if 'typeSchemaNode' not in node:
         return node['leafType'].lower()
 
     t = node['typeSchemaNode']
@@ -55,6 +55,7 @@ def pretty_type(node):
         return "union { %s }" % ', '.join(names)
     else:
         return t['leafType'].lower()
+
 
 def traverse(node, depth=0, name="root"):
     def output(*s, **kw):
@@ -94,13 +95,14 @@ def traverse(node, depth=0, name="root"):
         output(name, ":", "list of", pretty_type(node['leafSchemaNode']), config, description)
     elif node['nodeType'] == 'RPC':
         output(name, description, "(RPC)")
-        for name, item in ( ("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
+        for name, item in (("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
             if item in node:
                 traverse(node[item], depth+1, name)
             else:
                 output(name, "(NONE)", depth=depth+1)
     else:
         assert False, "unknown node type %s" % node['nodeType']
+
 
 path = args.path.replace('.', '/').replace('_', '-')
 
@@ -113,6 +115,6 @@ else:
     schema = bcf.schema(path)
 
 if args.raw:
-    print(json.dumps(schema, indent=4, cls=pybcf.BCFJSONEncoder))
+    print(json.dumps(schema, indent=4))
 else:
     traverse(schema, name=path)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -2,11 +2,7 @@ import json
 import logging
 import re
 from string import Template
-try:
-    from urlparse import urlparse  # python2
-except:
-    from urllib.parse import urlparse  # python3
-
+from urllib.parse import urlparse
 import requests
 
 try:
@@ -28,6 +24,7 @@ try:
     UNICODE_TYPE = unicode
 except NameError:
     UNICODE_TYPE = None
+
 
 class Node(object):
     """ Higher level "Node" abstraction for PyBSN.
@@ -171,7 +168,7 @@ class Node(object):
             else:
                 return repr(v)
 
-        kwargs = { k: _convert(v) for k, v in kwargs.items() }
+        kwargs = {k: _convert(v) for k, v in kwargs.items()}
         predicate = '[' + Template(template).substitute(**kwargs) + ']'
         return Node(self._path + predicate, self._connection)
 
@@ -334,15 +331,15 @@ def logged_request(session, request):
     marker = "-" * 30
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("%s Request: %s\n%s\n%s\n\n%s", marker, marker, prepared.method + ' ' + prepared.url,
-                  '\n'.join('{}: {}'.format(k, v) for k, v in prepared.headers.items()),
-                  prepared.body)
+                     '\n'.join('{}: {}'.format(k, v) for k, v in prepared.headers.items()),
+                     prepared.body)
 
     response = session.send(prepared)
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("%s Response: %s\n%s\n%s\n\n%s", marker, marker, response.status_code,
-                  '\n'.join('{}: {}'.format(k, v) for k, v in response.headers.items()),
-                  response.content)
+                     '\n'.join('{}: {}'.format(k, v) for k, v in response.headers.items()),
+                     response.content)
 
     return response
 
@@ -370,7 +367,7 @@ def guess_url(session, host, validate_path="/api/v1/auth/healthy"):
             except requests.exceptions.ConnectionError as e:
                 logger.debug("Error connecting to %s: %s", url, str(e))
                 continue
-            if response.status_code == 200: # OK
+            if response.status_code == 200:  # OK
                 return url
             else:
                 logger.debug("Could connect to URL %s: %s", url, response)
@@ -393,7 +390,7 @@ def _attempt_login(session, url, username, password):
 
 
 def _attempt_legacy_login(session, url, username, password):
-    auth_data = json.dumps({ 'user': username, 'password': password})
+    auth_data = json.dumps({'user': username, 'password': password})
     path = "/api/v1/auth/login"
     request = requests.Request(method="POST", url=url + path, data=auth_data)
     response = logged_request(session, request)
@@ -408,13 +405,15 @@ def _attempt_legacy_login(session, url, username, password):
 
 
 def _attempt_modern_login(session, url, username, password):
-    auth_data = json.dumps({ 'user': username, 'password': password })
+    auth_data = json.dumps({'user': username, 'password': password})
     path = "/api/v1/rpc/controller/core/aaa/session/login"
     request = requests.Request(method="POST", url=url + path, data=auth_data)
     response = logged_request(session, request)
     if response.status_code == 200:
         json_ = response.json()
-        session_cookie = requests.cookies.create_cookie(name="session_cookie", value=json_["session-cookie"], domain=urlparse(url).hostname, path="/api")
+        session_cookie = requests.cookies.create_cookie(
+            name="session_cookie", value=json_["session-cookie"],
+            domain=urlparse(url).hostname, path="/api")
         session.cookies.set_cookie(session_cookie)
         return url
     else:

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -4,26 +4,15 @@ import re
 from string import Template
 from urllib.parse import urlparse
 import requests
-
-try:
-    import warnings
-    from requests.packages.urllib3.exceptions import InsecureRequestWarning
-    warnings.simplefilter("ignore", InsecureRequestWarning)
-except ImportError:
-    pass
+import warnings
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+warnings.simplefilter("ignore", InsecureRequestWarning)
 
 logger = logging.getLogger("pybsn")
 
 DATA_PREFIX = "/api/v1/data/"
 RPC_PREFIX = "/api/v1/rpc/"
 SCHEMA_PREFIX = "/api/v1/schema/"
-
-
-# for python2, need to handle unicode strings specially in filter
-try:
-    UNICODE_TYPE = unicode
-except NameError:
-    UNICODE_TYPE = None
 
 
 class Node(object):
@@ -159,16 +148,7 @@ class Node(object):
         .../segment[member-vlan<1000]
         """
 
-        # TODO escape values better than repr()
-        def _convert(v):
-            # fix for py2: unicode strings are encoded as u'foo' - we can't have that in a predicate
-            # so convert to a "normal" string first.
-            if UNICODE_TYPE and isinstance(v, UNICODE_TYPE):
-                return repr(str(v))
-            else:
-                return repr(v)
-
-        kwargs = {k: _convert(v) for k, v in kwargs.items()}
+        kwargs = {k: repr(v) for k, v in kwargs.items()}
         predicate = '[' + Template(template).substitute(**kwargs) + ']'
         return Node(self._path + predicate, self._connection)
 
@@ -403,7 +383,6 @@ def _attempt_legacy_login(session, url, username, password):
     else:
         response.raise_for_status()
 
-
 def _attempt_modern_login(session, url, username, password):
     auth_data = json.dumps({'user': username, 'password': password})
     path = "/api/v1/rpc/controller/core/aaa/session/login"
@@ -418,7 +397,6 @@ def _attempt_modern_login(session, url, username, password):
         return url
     else:
         response.raise_for_status()
-
 
 def connect(host, username=None, password=None, token=None, login=None, verify_tls=False, session_headers=None):
     """ Creates a connected BigDb client.

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -383,6 +383,7 @@ def _attempt_legacy_login(session, url, username, password):
     else:
         response.raise_for_status()
 
+
 def _attempt_modern_login(session, url, username, password):
     auth_data = json.dumps({'user': username, 'password': password})
     path = "/api/v1/rpc/controller/core/aaa/session/login"
@@ -397,6 +398,7 @@ def _attempt_modern_login(session, url, username, password):
         return url
     else:
         response.raise_for_status()
+
 
 def connect(host, username=None, password=None, token=None, login=None, verify_tls=False, session_headers=None):
     """ Creates a connected BigDb client.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 responses
-nose
 requests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pybsn',
-    version='0.3.3',
+    version='0.4.0',
     description="pybsn is a python interface to Big Switch Networks' products",
     url='https://github.com/floodlight/pybsn',
     author='Andreas Wundsam, Andre Kutzleb, Jason Parraga, Rich Lane',

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -1,9 +1,0 @@
-[run]
-source = 
-	pybsn
-
-[report]
-omit =  
-    */python?.?/*
-    */site-packages/nose/*
-    /*/test/*


### PR DESCRIPTION
Suggested to review by commit: 
1. 6deed24 enforce PEP8 standards, drop nosetest dependencies. check coverage as part of Github Test action:
![image](https://user-images.githubusercontent.com/19155548/107445395-34c63680-6af1-11eb-8a9a-8908805f2162.png)
2. 35be8b3 stop python2 testing
3. 18e8910, cd9623f refactor to conform to PEP8 / quality gate
4. d83810b remove coveragerc config file, these are part of the command line arguments in `run-tests.yml` (see 6deed24)
5. d1295fc updates the docs and adds a `CONTRIBUTORS.MD` that explains how the contribution process, as well as the automated release process works.
6. d64d59f source-level changes to drop python2 compatibility