### PR TITLE
Consolidate flake8 commands

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,18 +23,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install coverage flake8
-        python -m pip install -r requirements.txt
+      run: make install-deps
 
     - name: Check syntax and enforce PEP8, 127 char Github editor width
-      run: flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --show-source --statistics
+      run: make check
 
     - name: Run unit tests with coverage
       # Exclude dependencies in coverage report with --omit
-      run: coverage run --omit */*-packages/* -m unittest discover -v
+      run: make coverage
 
     - name: Check Coverage Results
         # Could gate here to prevent pass under certain coverage %
-      run: coverage report
+      run: make coverage-report

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,11 +28,8 @@ jobs:
         python -m pip install coverage flake8
         python -m pip install -r requirements.txt
 
-    - name: Enforce Github editor 127 character width
-      run: flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --statistics
-
-    - name: Check syntax errors and undefined names
-      run: flake8 ./pybsn/ ./bin/* --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Check syntax and enforce PEP8, 127 char Github editor width
+      run: flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --show-source --statistics
 
     - name: Run unit tests with coverage
       # Exclude dependencies in coverage report with --omit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+check:
+	flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --show-source --statistics
+
+coverage:
+	coverage run --omit */*-packages/* -m unittest discover -v
+
+coverage-report:
+	coverage report
+
+install-deps:
+	# for development, consider running in a pipenv/venv
+	python -m pip install --upgrade pip
+	python -m pip install coverage flake8
+	python -m pip install -r requirements.txt


### PR DESCRIPTION
Simplify the style check. One pass will catch all issues. Before, it would show style issues with less verbosity, and syntax errors with more verbosity. This seems like unnecessary complexity that makes this tool look harder to use than it really is.

This PR incorporates the changes from #41.

---

![image](https://user-images.githubusercontent.com/19155548/108407199-43d77380-71d8-11eb-8fb3-a3fe9a92c220.png)
 