### PR TITLE
Add url parameter option to RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
  - added optional parameter `params` to all BigDbClient and Node request methods. It allows
    specifying additional query paramters for the BigDB request (e.g., `transaction` or
    `state-type` parameters).
+ - added optional parameter `params` to RPC to manually initiate async RPC calls.
+   e.g., `initiate-async-id`, `'async-id'`
 ### Removed
 - python 2 support has been removed.
 - nosetest has been removed as dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
    specifying additional query paramters for the BigDB request (e.g., `transaction` or
    `state-type` parameters).
  - added optional parameter `params` to RPC to manually initiate async RPC calls.
-   e.g., `initiate-async-id`, `'async-id'`
+   e.g., `initiate-async-id`, `async-id`
 ### Removed
 - python 2 support has been removed.
 - nosetest has been removed as dependency.

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -118,6 +118,8 @@ class Node(object):
 
          :param data to provide as RPC input to BigDB.
             Note that the data provided here is passed to BigDB as-is; i.e., use hyphens.
+         :params params: Optional hash of parameters that will be appended to the query
+e.g., {'initiate-async-id': '(async-id-here)'} would initiate RPC call asynchronously.
          :return the output data returned by the RPC endpoint.
         """
         return self._connection.rpc(self._path, data, params)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -217,10 +217,15 @@ class BigDbClient(object):
         :return: the deserialized RPC output (for most RPCs, a dict).
         """
         response = self._request("POST", path, data=self._dump_if_present(data), rpc=True, params=params)
-        try:
-            return response.json()
-        except ValueError:
+        if response.status_code == requests.codes.no_content:
             return None
+        elif response.status_code == requests.codes.accepted:
+            try:
+                return response.json()
+            except (json.JSONDecodeError, ValueError):
+                return None
+        else:
+            return response.json()
 
     def post(self, path, data, params=None):
         """ Inserts new data to the BigDB REST API via the POST method.

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -113,14 +113,14 @@ class Node(object):
         """ Retrieve the schema for BigDB at the path identified by this node. """
         return self._connection.schema(self._path)
 
-    def rpc(self, data=None):
+    def rpc(self, data=None, params=None):
         """ Invoke the BigDB RPC endpoint identified by this node.
 
          :param data to provide as RPC input to BigDB.
             Note that the data provided here is passed to BigDB as-is; i.e., use hyphens.
          :return the output data returned by the RPC endpoint.
         """
-        return self._connection.rpc(self._path, data)
+        return self._connection.rpc(self._path, data, params)
 
     def match(self, **kwargs):
         """ Adds exact match predicates to the path represented by the current Node. Returns
@@ -205,7 +205,7 @@ class BigDbClient(object):
         """
         return self._request("GET", path, params=params).json()
 
-    def rpc(self, path, data):
+    def rpc(self, path, data, params=None):
         """ Invokes an RPC endpoint on the REST API.
 
         :param path: the path path of the RPC to invoke. Does not include the prefix.
@@ -214,11 +214,11 @@ class BigDbClient(object):
         :param params: request parameters to attach
         :return: the deserialized RPC output (for most RPCs, a dict).
         """
-        response = self._request("POST", path, data=self._dump_if_present(data), rpc=True)
-        if response.status_code == requests.codes.no_content:
-            return None
-        else:
+        response = self._request("POST", path, data=self._dump_if_present(data), rpc=True, params=params)
+        try:
             return response.json()
+        except ValueError:
+            return None
 
     def post(self, path, data, params=None):
         """ Inserts new data to the BigDB REST API via the POST method.

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -245,6 +245,15 @@ class TestBigDBClient(unittest.TestCase):
         self.assertEqual(result, {'id': 1234})
 
     @responses.activate
+    def test_rpc_async_accepted(self):
+        responses.add(responses.POST, "http://127.0.0.1:8080/api/v1/rpc/controller/rpc",
+                      status=202)
+        result = self.client.rpc(path="controller/rpc",
+                                 data={"description": "desc"},
+                                 params={'initiate-async': 'asyncId'})
+        self.assertEqual(result, None)
+
+    @responses.activate
     def test_no_response(self):
         responses.add(responses.POST, "http://127.0.0.1:8080/api/v1/rpc/controller/rpc",
                       status=204)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -81,7 +81,15 @@ class TestNode(unittest.TestCase):
 
         self.assertEqual(ret, dict(foo="bar"))
         self.client.rpc.assert_called_with("controller/core/aaa/test",
-            dict(input="foo"))
+            dict(input="foo"), None)
+
+    def test_rpc_params(self):
+        self.client.rpc.return_value = dict(foo="bar")
+        ret = self.root.core.aaa.test.rpc(dict(input="foo"), params={'initiate-async-id': 'asyncId'})
+
+        self.assertEqual(ret, dict(foo="bar"))
+        self.client.rpc.assert_called_with("controller/core/aaa/test",
+            dict(input="foo"), {'initiate-async-id': 'asyncId'})
 
     def test_match(self):
         self.client.rpc.return_value = dict(foo="bar")


### PR DESCRIPTION
Add url parameter option to RPC calls to support initiating async RPC calls, etc.
