### PR TITLE
BSC-14299 timeout BigDBClient

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -39,6 +39,7 @@ TimeoutDefault = Union[type(None), TimeoutSauce, float]
    Otherwise the value specified is the number of seconds.
 """
 
+
 class TimeoutSession(requests.Session):
     """Have a configurable value for timing out requests."""
 
@@ -209,53 +210,75 @@ class Node(object):
         """
         return Node(self._path + "/" + name, self._connection)
 
-    def get(self, params=None):
+    def get(self, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
         """ Retrieve the data stored in BigDB at the path identified by this node.
 
         :params params: Optional hash of parameters that will be appended to the query
             e.g., {'state-type': 'global-config'} would restrict the state to global config.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
         """
-        return self._connection.get(self._path, params)
+        return self._connection.get(self._path, params, timeout=timeout)
 
-    def post(self, data, params=None):
+    def post(self, data, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
         """ Inserts (POST) the given data to BigDB at the path identified by this node.
 
         :param data: JSON serializable data to post, often a dictionary.
             Note that the data provided here is passed to BigDB as-is; i.e., use hyphens.
         :params params: Optional hash of parameters that will be appended to the query
             e.g., {'state-type': 'global-config'} would restrict the state to global config.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
         """
-        return self._connection.post(self._path, data, params)
+        return self._connection.post(self._path, data, params, timeout=timeout)
 
-    def put(self, data, params=None):
+    def put(self, data, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
         """ Replaces (PUT) the given data in BigDB at the path identified by this node.
 
         :param data: JSON serializable data to post, often a dictionary.
             Note that the data provided here is passed to BigDB as-is; i.e., use hyphens.
         :params params: Optional hash of parameters that will be appended to the query
             e.g., {'state-type': 'global-config'} would restrict the state to global config.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
         """
-        return self._connection.put(self._path, data, params)
+        return self._connection.put(self._path, data, params, timeout=timeout)
 
-    def patch(self, data, params=None):
+    def patch(self, data, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
         """ Updates (PATCH) the given data in BigDB at the path identified by this node.
 
         :param data: JSON serializable data to post, often a dictionary.
             Note that the data provided here is passed to BigDB as-is; i.e., use hyphens.
         :params params: Optional hash of parameters that will be appended to the query
             e.g., {'state-type': 'global-config'} would restrict the state to global config.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
         """
-        return self._connection.patch(self._path, data, params)
+        return self._connection.patch(self._path, data, params, timeout=timeout)
 
-    def delete(self, params=None):
-        """ Delete the data stored in BigDB at the path identified by this node. """
-        return self._connection.delete(self._path, params=params)
+    def delete(self, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
+        """ Delete the data stored in BigDB at the path identified by this node.
+        :params params: Optional hash of parameters that will be appended to the query
+            e.g., {'state-type': 'global-config'} would restrict the state to global config.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
+        """
+        return self._connection.delete(self._path, params=params, timeout=timeout)
 
-    def schema(self):
-        """ Retrieve the schema for BigDB at the path identified by this node. """
-        return self._connection.schema(self._path)
+    def schema(self, timeout: TimeoutOverride = CLIENT_TIMEOUT):
+        """ Retrieve the schema for BigDB at the path identified by this node.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
+        """
+        return self._connection.schema(self._path, timeout=timeout)
 
-    def rpc(self, data=None, params=None):
+    def rpc(self, data=None, params=None, timeout: TimeoutOverride = CLIENT_TIMEOUT):
         """ Invoke the BigDB RPC endpoint identified by this node.
 
          :param data to provide as RPC input to BigDB.
@@ -263,8 +286,11 @@ class Node(object):
          :params params: Optional hash of parameters that will be appended to the query
 e.g., {'initiate-async-id': '(async-id-here)'} would initiate RPC call asynchronously.
          :return the output data returned by the RPC endpoint.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
         """
-        return self._connection.rpc(self._path, data, params)
+        return self._connection.rpc(self._path, data, params, timeout=timeout)
 
     def match(self, **kwargs):
         """ Adds exact match predicates to the path represented by the current Node. Returns
@@ -306,8 +332,13 @@ e.g., {'initiate-async-id': '(async-id-here)'} would initiate RPC call asynchron
         predicate = '[' + Template(template).substitute(**kwargs) + ']'
         return Node(self._path + predicate, self._connection)
 
-    def __call__(self):
-        return self.get()
+    def __call__(self, timeout: TimeoutOverride = CLIENT_TIMEOUT):
+        """ Execute get method.
+        :param timeout: Amount of time to wait for response.  None indicates
+            to wait forever.  CLIENT_TIMEOUT indicates to use the default value
+            from BigDbClient
+        """
+        return self.get(timeout=timeout)
 
     def __enter__(self):
         return self

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -567,8 +567,7 @@ def _attempt_modern_login(session, url, username, password, timeout):
 
 def connect(host, username=None, password=None, token=None, login=None,
             verify_tls=False, session_headers=None,
-            timeout=None,
-            *args, **kwargs) -> BigDbClient:
+            timeout=None):
     """ Creates a connected BigDb client.
 
     Main entrypoint to pybsn.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 responses
 requests
+urllib3

--- a/test/fakeserver.py
+++ b/test/fakeserver.py
@@ -1,0 +1,200 @@
+import json
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from itertools import repeat
+from typing import Iterable
+
+# How long to wait in seconds before sending a response in a test
+# case where we are checking that we will wait forever.
+FOREVER_BLOCKING_TIME = 10
+
+
+class BlockingServer(HTTPServer):
+
+    # Amount of time to wait, in seconds, before sending a GET response.
+    get_blocking = repeat(StopIteration, 1)
+
+    # Has the server been _stopped so it no longer needs to
+    # return responses.
+    _stopped = False
+    _lock = threading.Lock()
+
+    # noinspection PyPep8Naming
+    def __init__(self, server_address, RequestHandlerClass):
+        super().__init__(server_address, RequestHandlerClass)
+
+    def is_stopped(self) -> bool:
+        with self._lock:
+            return self._stopped
+
+    def shutdown(self) -> None:
+        super().shutdown()
+        with self._lock:
+            self._stopped = True
+
+
+class FakeHandler(BaseHTTPRequestHandler):
+    """Override the server type from BaseServer."""
+
+    def _server(self) -> BlockingServer:
+        """Casting self.server for Python checking."""
+        # noinspection PyTypeChecker
+        return self.server
+
+    def _block(self, delay_list: Iterable) -> None:
+        """Delay for a period of time.
+
+        Attributes:
+            delay_list: Top value will be removed and used as the number
+            of seconds to wait.
+        """
+        delay = delay_list.__next__()
+        if delay == StopIteration:
+            # noinspection PyProtectedMember
+            msg = f"delay_list is empty: {self._server()._testMethodName}"
+            raise Exception(msg)
+
+        while delay > 0 and not self._server().is_stopped():
+            time.sleep(0.5)
+            delay -= 0.5
+
+    # noinspection PyPep8Naming
+    def do_HEAD(self) -> None:
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_GET(self) -> None:
+        self._block(self._server().get_blocking)
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        result = [{"auth-context-type": "session-token",
+                   "user-info": {"full-name": "Default admin",
+                                 "group": ["admin"], "user-name": "admin"}}]
+        result_as_str = json.dumps(result)
+        result_as_bytes = bytes(result_as_str, "utf8")
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", str(len(result_as_bytes)))
+        self.end_headers()
+        self.wfile.write(result_as_bytes)
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_OPTIONS(self) -> None:
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        result = ["OPTIONS"]
+        result_as_str = json.dumps(result)
+        result_as_bytes = bytes(result_as_str, "utf8")
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", str(len(result_as_bytes)))
+        self.end_headers()
+        self.wfile.write(result_as_bytes)
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_POST(self) -> None:
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        result_as_str = json.dumps(
+            {"success": True,
+             "session-cookie": "UPhNWlmDN0re8cg9xsqe9QT1QvQTznji",
+             "error-message": "",
+             "past-login-info":
+                 {"failed-login-count": 0,
+                  "last-success-login-info": {"host": "127.0.0.1", "timestamp": "2019-05-19T19:16:22.328Z"}}})
+        result_as_bytes = bytes(result_as_str, "utf8")
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", str(len(result_as_bytes)))
+        self.end_headers()
+        self.wfile.write(result_as_bytes)
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_PUT(self):
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", "0")
+        self.end_headers()
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_PATCH(self):
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", "0")
+        self.end_headers()
+        self.close_connection = True
+
+    # noinspection PyPep8Naming
+    def do_DELETE(self):
+        if self._server().is_stopped():
+            self.send_error(500, "server is _stopped")
+            return
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("content-length", "0")
+        self.end_headers()
+        self.close_connection = True
+
+
+class FakeServer:
+    thread = None
+    server = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.server = BlockingServer(('localhost', 0), FakeHandler)
+
+    def _run_server(self):
+        self.server.serve_forever()
+
+    def get_blocking(self, delay: Iterable[float]):
+        """Set the amount of time to wait prior to responding to
+           a GET request.
+
+           :parameter delay Amount of seconds to wait.
+        """
+        self.server.get_blocking = delay
+
+
+    def start(self):
+        # noinspection PyBroadException
+        try:
+            self.thread = threading.Thread(
+                name="FakeServer",
+                target=self._run_server)
+            self.thread.start()
+            return True
+        except Exception:
+            print(f'unable to start server on port {self.server.server_port}')
+            return False
+
+    def port(self) -> int:
+        """:return port the server is listening on."""
+        return self.server.server_port
+
+    def stop(self):
+        if self.thread.is_alive():
+            self.server.shutdown()
+        self.thread.join(timeout=60)
+        if self.thread.is_alive():
+            raise Exception("Server thread did not terminate")

--- a/test/fakeserver.py
+++ b/test/fakeserver.py
@@ -165,18 +165,18 @@ class FakeServer:
     thread = None
     server = None
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         self.server = BlockingServer(('localhost', 0), FakeHandler)
 
     def _run_server(self):
         self.server.serve_forever()
 
-    def get_blocking(self, delay: Iterable[float]):
+    def get_blocking(self, delay):
         """Set the amount of time to wait prior to responding to
            a GET request.
 
-           :parameter delay Amount of seconds to wait.
+           :parameter delay Amount of seconds to wait. Iterable[float]
         """
         self.server.get_blocking = delay
 
@@ -193,7 +193,7 @@ class FakeServer:
             print(f'unable to start server on port {self.server.server_port}')
             return False
 
-    def port(self) -> int:
+    def port(self):
         """:return port the server is listening on."""
         return self.server.server_port
 

--- a/test/mockutils.py
+++ b/test/mockutils.py
@@ -12,3 +12,4 @@ def get_mockcall_attribute(mock_call, name):
             if name in kwargs:
                 return kwargs[name]
     raise Exception("named attribute not found: " + name)
+

--- a/test/mockutils.py
+++ b/test/mockutils.py
@@ -1,0 +1,14 @@
+# Utilities for checking mocking
+
+def get_mockcall_attribute(mock_call, name):
+    """Get the named attribute from a mock call.
+
+    Python 3.6 version of:
+            self.assertIsNone(mock_call.kwargs['name'])
+    """
+    for part_index in range(0,len(mock_call)):
+        if type(mock_call[part_index]) == dict:
+            kwargs = mock_call[part_index]
+            if name in kwargs:
+                return kwargs[name]
+    raise Exception("named attribute not found: " + name)

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -3,7 +3,6 @@ import os
 import logging
 import re
 import unittest
-import urllib.error
 from unittest.mock import patch
 import requests
 

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -8,11 +8,15 @@ from unittest.mock import Mock
 import requests
 
 import pybsn
+from pybsn import BigDbClient, CLIENT_TIMEOUT
 import responses
 
 my_dir = os.path.dirname(__file__)
 
 PARAMS = {'state-type': 'global-config'}
+
+SHORT_BLOCKING_TIME = 5.0
+short_timeout = pybsn.TimeoutSauce(connect=SHORT_BLOCKING_TIME, read=SHORT_BLOCKING_TIME)
 
 class TestNode(unittest.TestCase):
     def setUp(self):
@@ -30,50 +34,78 @@ class TestNode(unittest.TestCase):
     def test_root_get(self):
         self.client.get.return_value = dict(foo="bar")
         self.assertEqual(self.root.get(), dict(foo="bar"))
-        self.client.get.assert_called_with("controller", None)
+        self.client.get.assert_called_with("controller", None, timeout=CLIENT_TIMEOUT)
 
     def test_root_get_with_params(self):
         self.client.get.return_value = dict(foo="bar")
         self.assertEqual(self.root.get(params=PARAMS), dict(foo="bar"))
-        self.client.get.assert_called_with("controller", PARAMS)
+        self.client.get.assert_called_with("controller", PARAMS, timeout=CLIENT_TIMEOUT)
+
+    def test_root_get_with_timeout(self):
+        self.client.get.return_value = dict(foo="bar")
+        self.root.get(timeout=short_timeout)
+        self.client.get.assert_called_with('controller', None, timeout=short_timeout)
+
 
     def test_root_post(self):
         self.root.post(data=dict(foo="bar"))
-        self.client.post.assert_called_with("controller", dict(foo="bar"), None)
+        self.client.post.assert_called_with("controller", dict(foo="bar"), None, timeout=CLIENT_TIMEOUT)
 
     def test_root_post_with_params(self):
         self.root.post(data=dict(foo="bar"), params=PARAMS)
-        self.client.post.assert_called_with("controller", dict(foo="bar"), PARAMS)
+        self.client.post.assert_called_with("controller", dict(foo="bar"), PARAMS, timeout=CLIENT_TIMEOUT)
+
+    def test_root_post_with_timeout(self):
+        self.root.post(data=dict(foo="bar"), params=PARAMS, timeout=short_timeout)
+        self.client.post.assert_called_with("controller", dict(foo="bar"), PARAMS, timeout=short_timeout)
 
     def test_root_put(self):
         self.root.put(data=dict(foo="bar"))
-        self.client.put.assert_called_with("controller", dict(foo="bar"), None)
+        self.client.put.assert_called_with("controller", dict(foo="bar"), None, timeout=CLIENT_TIMEOUT)
 
     def test_root_put_with_params(self):
         self.root.put(data=dict(foo="bar"), params=PARAMS)
-        self.client.put.assert_called_with("controller", dict(foo="bar"), PARAMS)
+        self.client.put.assert_called_with("controller", dict(foo="bar"), PARAMS, timeout=CLIENT_TIMEOUT)
+
+    def test_root_put_with_timeout(self):
+        self.root.put(data=dict(foo="bar"), params=PARAMS, timeout=short_timeout)
+        self.client.put.assert_called_with("controller", dict(foo="bar"), PARAMS, timeout=short_timeout)
 
     def test_root_patch(self):
         self.root.patch(data=dict(foo="bar"))
-        self.client.patch.assert_called_with("controller", dict(foo="bar"), None)
+        self.client.patch.assert_called_with("controller", dict(foo="bar"), None, timeout=CLIENT_TIMEOUT)
 
     def test_root_patch_with_params(self):
         self.root.patch(data=dict(foo="bar"), params=PARAMS)
-        self.client.patch.assert_called_with("controller", dict(foo="bar"), PARAMS)
+        self.client.patch.assert_called_with("controller", dict(foo="bar"), PARAMS, timeout=CLIENT_TIMEOUT)
+
+    def test_root_patch_with_timeout(self):
+        self.root.patch(data=dict(foo="bar"), timeout=short_timeout)
+        self.client.patch.assert_called_with("controller", dict(foo="bar"), None, timeout=short_timeout)
 
     def test_root_delete(self):
         self.root.delete()
-        self.client.delete.assert_called_with("controller", params=None)
+        self.client.delete.assert_called_with("controller", params=None, timeout=CLIENT_TIMEOUT)
 
     def test_root_delete_with_params(self):
         self.root.delete(params=PARAMS)
-        self.client.delete.assert_called_with("controller", params=PARAMS)
+        self.client.delete.assert_called_with("controller", params=PARAMS,timeout=CLIENT_TIMEOUT)
+
+    def test_root_delete_with_timeout(self):
+        self.root.delete(timeout=short_timeout)
+        self.client.delete.assert_called_with("controller", params=None, timeout=short_timeout)
 
     def test_root_schema(self):
         self.client.schema.return_value = dict(foo="bar")
         ret = self.root.schema()
         self.assertEqual(ret, dict(foo="bar"))
-        self.client.schema.assert_called_with("controller")
+        self.client.schema.assert_called_with("controller",timeout=CLIENT_TIMEOUT)
+
+    def test_root_schema_with_timeout(self):
+        self.client.schema.return_value = dict(foo="bar")
+        ret = self.root.schema(timeout=short_timeout)
+        self.assertEqual(ret, dict(foo="bar"))
+        self.client.schema.assert_called_with("controller",timeout=short_timeout)
 
     def test_rpc(self):
         self.client.rpc.return_value = dict(foo="bar")
@@ -81,7 +113,7 @@ class TestNode(unittest.TestCase):
 
         self.assertEqual(ret, dict(foo="bar"))
         self.client.rpc.assert_called_with("controller/core/aaa/test",
-            dict(input="foo"), None)
+            dict(input="foo"), None,timeout=CLIENT_TIMEOUT)
 
     def test_rpc_params(self):
         self.client.rpc.return_value = dict(foo="bar")
@@ -89,7 +121,15 @@ class TestNode(unittest.TestCase):
 
         self.assertEqual(ret, dict(foo="bar"))
         self.client.rpc.assert_called_with("controller/core/aaa/test",
-            dict(input="foo"), {'initiate-async-id': 'asyncId'})
+            dict(input="foo"), {'initiate-async-id': 'asyncId'},timeout=CLIENT_TIMEOUT)
+
+    def test_rpc_with_timeout(self):
+        self.client.rpc.return_value = dict(foo="bar")
+        ret = self.root.core.aaa.test.rpc(dict(input="foo"),timeout=short_timeout)
+
+        self.assertEqual(ret, dict(foo="bar"))
+        self.client.rpc.assert_called_with("controller/core/aaa/test",
+            dict(input="foo"), None,timeout=short_timeout)
 
     def test_match(self):
         self.client.rpc.return_value = dict(foo="bar")
@@ -113,4 +153,9 @@ class TestNode(unittest.TestCase):
     def test_root_call(self):
         self.client.get.return_value = dict(foo="bar")
         self.assertEqual(self.root(), dict(foo="bar"))
-        self.client.get.assert_called_with("controller", None)
+        self.client.get.assert_called_with("controller", None, timeout=CLIENT_TIMEOUT)
+
+    def test_root_call_with_timeout(self):
+        self.client.get.return_value = dict(foo="bar")
+        self.assertEqual(self.root(timeout=short_timeout), dict(foo="bar"))
+        self.client.get.assert_called_with("controller", None, timeout=short_timeout)

--- a/test/test_timeout_bigdbclient.py
+++ b/test/test_timeout_bigdbclient.py
@@ -1,0 +1,316 @@
+import json
+import sys
+import unittest
+from unittest.mock import patch
+
+import requests
+import responses
+
+import pybsn
+
+sys.path.append("test")
+from fakeserver import FOREVER_BLOCKING_TIME
+
+MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
+short_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME / 2.0, read=MIDDLE_BLOCKING_TIME / 2.0)
+middle_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME, read=MIDDLE_BLOCKING_TIME)
+long_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
+
+
+class SuccessfulResponse:
+    text = '{"schema":"big"}'
+
+    def raise_for_status(self):
+        pass
+
+
+class TestTimeoutBigDbClient(unittest.TestCase):
+    # noinspection GrazieInspection
+    """Check that the timeout value passed to Session.send is correct.
+           A timeout value is always passed through from BigDbClient calls.
+        """
+    url = "http://127.0.0.1:8080"
+
+    # def setUp(self):
+    #     self.client = pybsn.connect("http://127.0.0.1:8080")
+
+    def _login_cb(self, req):
+        self.assertEqual(json.loads(req.body), {'user': 'admin', 'password': 'somepassword'})
+        headers = {
+            "Set-Cookie": "session_cookie=v_8yOI7FI-WKr-5QU6nxoJkVtAu5rKI-; Path=/api/;"
+        }
+        return (200, headers, json.dumps(
+            {"success": True,
+             "session-cookie": "UPhNWlmDN0re8cg9xsqe9QT1QvQTznji",
+             "error-message": "",
+             "past-login-info":
+                 {"failed-login-count": 0,
+                  "last-success-login-info": {"host": "127.0.0.1", "timestamp": "2019-05-19T19:16:22.328Z"}}}))
+
+    def _add_login_responses(self):
+        responses.add_callback(responses.HEAD,
+                               "http://127.0.0.1:8080/api/v2/schema/controller/root/core/aaa/session/login",
+                               callback=lambda req: (200, {}, ""),
+                               content_type="application/json")
+        responses.add_callback(responses.POST,
+                               "http://127.0.0.1:8080/api/v1/rpc/controller/core/aaa/session/login",
+                               callback=self._login_cb,
+                               content_type="application/json")
+
+    @responses.activate
+    def test_get_timeout_default(self):
+        """GET response retrieved with the default timeout which is None,
+           meaning wait forever.
+        """
+        self._add_login_responses()
+
+        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.get(self.url)
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_get_timeout_uses_client_default(self):
+        """The timeout that is used when creating the client is used for
+           GET when no override is specified.
+        """
+        self._add_login_responses()
+
+        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword",
+                               timeout=short_timeout)
+
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.get(self.url)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_get_timeout_arg(self):
+        """GET specified timeout is used."""
+        self._add_login_responses()
+        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.get(self.url, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_get_timeout_arg_none(self):
+        """GET timeout argument of None indicates to wait forever."""
+        self._add_login_responses()
+        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword", timeout=short_timeout.read_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.get(self.url, timeout=None)
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_get_timeout_arg_client_timeout(self):
+        """GET timeout argument of CLIENT_TIMEOUT indicates to use the timeout
+          value from when BigDbClient was created.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=middle_timeout.read_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.get(self.url, timeout=pybsn.CLIENT_TIMEOUT)
+            self.assertEqual(middle_timeout.read_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_rpc_no_timeout(self):
+        """RPC call without timeout usesNone which means waits forever until response."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.rpc(self.url, data={})
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_rpc_timeout(self):
+        """RPC call without timeout uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.rpc(self.url, data={})
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_rpc_timeout_arg(self):
+        """RPC call uses timeout argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.rpc(self.url, data={}, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_post_no_timeout(self):
+        """POST call without timeout uses default None."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.post(self.url, data={})
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_post_timeout(self):
+        """POST call without argument uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.post(self.url, data={})
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_post_timeout_arg(self):
+        """POST call uses argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.post(self.url, data={}, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_put_no_timeout(self):
+        """PUT call without timeout uses None."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.put(self.url, data={})
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_put_timeout(self):
+        """PUT call without argument uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.put(self.url, data={})
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_put_timeout_arg(self):
+        """PUT call uses argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.put(self.url, data={}, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_patch_no_timeout(self):
+        """PATCH call without timeout uses None."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.patch(self.url, data={})
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_patch_timeout(self):
+        """PATCH call without argument uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.patch(self.url, data={})
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_patch_timeout_arg(self):
+        """PATCH call uses argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.patch(self.url, data={}, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_delete_no_timeout(self):
+        """DELETE call without timeout uses None."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.delete(self.url)
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_delete_timeout(self):
+        """DELETE call without argument uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.delete(self.url)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_delete_timeout_arg(self):
+        """DELETE call uses argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            client.delete(self.url, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_schema_no_timeout(self):
+        """SCHEMA call without timeout uses None."""
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            mock_send.return_value = SuccessfulResponse()
+            client.schema(self.url)
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_schema_timeout(self):
+        """SCHEMA call will without argument uses client default.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            mock_send.return_value = SuccessfulResponse()
+            client.schema(self.url)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_schema_timeout_arg(self):
+        """SCHEMA call uses argument.
+        """
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        with patch.object(requests.Session, 'send') as mock_send:
+            mock_send.return_value = SuccessfulResponse()
+            client.schema(self.url, timeout=short_timeout)
+            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_default_argument_can_be_changed(self):
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        client.set_default_timeout(middle_timeout)
+        with patch.object(requests.Session, 'send') as mock_send:
+            mock_send.return_value = SuccessfulResponse()
+            client.schema(self.url)
+            self.assertEqual(middle_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+
+    @responses.activate
+    def test_default_argument_can_be_retrieved(self):
+        self._add_login_responses()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+                                                  timeout=short_timeout)
+        actual = client.get_default_timeout()
+        self.assertEqual(short_timeout, actual)

--- a/test/test_timeout_bigdbclient.py
+++ b/test/test_timeout_bigdbclient.py
@@ -34,10 +34,6 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """
     url = "http://127.0.0.1:8080"
 
-    # def setUp(self):
-    #     self.client = pybsn.connect("http://127.0.0.1:8080")
-
-
     def _assertTimeoutValue(self, expected_value, mock_call):
         actual = get_mockcall_attribute(mock_call, "timeout")
         self.assertEqual(expected_value, actual)

--- a/test/test_timeout_bigdbclient.py
+++ b/test/test_timeout_bigdbclient.py
@@ -1,10 +1,10 @@
 import json
+import requests
+import responses
 import sys
 import unittest
 from unittest.mock import patch
-
-import requests
-import responses
+import urllib3
 
 import pybsn
 
@@ -13,9 +13,9 @@ from fakeserver import FOREVER_BLOCKING_TIME
 
 MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
 SHORT_BLOCKING_TIME = MIDDLE_BLOCKING_TIME / 2.0
-short_timeout = pybsn.TimeoutSauce(connect=SHORT_BLOCKING_TIME, read=SHORT_BLOCKING_TIME)
-middle_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME, read=MIDDLE_BLOCKING_TIME)
-long_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
+short_timeout = urllib3.util.Timeout(connect=SHORT_BLOCKING_TIME, read=SHORT_BLOCKING_TIME)
+middle_timeout = urllib3.util.Timeout(connect=MIDDLE_BLOCKING_TIME, read=MIDDLE_BLOCKING_TIME)
+long_timeout = urllib3.util.Timeout(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
 
 
 class SuccessfulResponse:
@@ -134,7 +134,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
           value from when BigDbClient was created.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=middle_timeout.read_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.get(self.url, timeout=pybsn.CLIENT_TIMEOUT)
@@ -144,7 +144,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_rpc_no_timeout(self):
         """RPC call without timeout usesNone which means waits forever until response."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.rpc(self.url, data={})
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
@@ -154,7 +154,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """RPC call without timeout uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.rpc(self.url, data={})
@@ -165,7 +165,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """RPC call uses timeout argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.rpc(self.url, data={}, timeout=short_timeout)
             self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
@@ -174,7 +174,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_post_no_timeout(self):
         """POST call without timeout uses default None."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.post(self.url, data={})
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
@@ -184,7 +184,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """POST call without argument uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.post(self.url, data={})
@@ -195,7 +195,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """POST call uses argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.post(self.url, data={}, timeout=short_timeout)
             self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
@@ -204,7 +204,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_put_no_timeout(self):
         """PUT call without timeout uses None."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.put(self.url, data={})
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
@@ -214,7 +214,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """PUT call without argument uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.put(self.url, data={})
@@ -225,7 +225,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """PUT call uses argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.put(self.url, data={}, timeout=short_timeout)
             self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
@@ -234,7 +234,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_patch_no_timeout(self):
         """PATCH call without timeout uses None."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.patch(self.url, data={})
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
@@ -244,7 +244,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """PATCH call without argument uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.patch(self.url, data={})
@@ -255,7 +255,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """PATCH call uses argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.patch(self.url, data={}, timeout=short_timeout)
             self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
@@ -264,7 +264,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_delete_no_timeout(self):
         """DELETE call without timeout uses None."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.delete(self.url)
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
@@ -274,7 +274,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """DELETE call without argument uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             client.delete(self.url)
@@ -285,7 +285,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """DELETE call uses argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             client.delete(self.url, timeout=short_timeout)
             self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
@@ -294,7 +294,7 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     def test_schema_no_timeout(self):
         """SCHEMA call without timeout uses None."""
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             mock_send.return_value = SuccessfulResponse()
             client.schema(self.url)
@@ -305,19 +305,20 @@ class TestTimeoutBigDbClient(unittest.TestCase):
         """SCHEMA call will without argument uses client default.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
         with patch.object(requests.Session, 'send') as mock_send:
             mock_send.return_value = SuccessfulResponse()
             client.schema(self.url)
-            self.assertEqual(short_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+            actual_timeout = mock_send.mock_calls[0].kwargs['timeout']
+            self.assertEqual(short_timeout, actual_timeout)
 
     @responses.activate
     def test_schema_timeout_arg(self):
         """SCHEMA call uses argument.
         """
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword")
+        client = pybsn.connect(self.url, "admin", "somepassword")
         with patch.object(requests.Session, 'send') as mock_send:
             mock_send.return_value = SuccessfulResponse()
             client.schema(self.url, timeout=short_timeout)
@@ -326,18 +327,22 @@ class TestTimeoutBigDbClient(unittest.TestCase):
     @responses.activate
     def test_default_argument_can_be_changed(self):
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
-        client.set_default_timeout(middle_timeout)
-        with patch.object(requests.Session, 'send') as mock_send:
-            mock_send.return_value = SuccessfulResponse()
+        client.default_timeout = middle_timeout
+
+        def has_new_timeout(mock_call):
+            return mock_call.kwargs['timeout'] == middle_timeout
+
+        with patch.object(requests.Session, 'send') as mock_get:
+            mock_get.return_value = SuccessfulResponse()
             client.schema(self.url)
-            self.assertEqual(middle_timeout, mock_send.mock_calls[0].kwargs['timeout'])
+            self.assertTrue(all(has_new_timeout(call) for call in mock_get.mock_calls))
+            mock_get.assert_called()
 
     @responses.activate
     def test_default_argument_can_be_retrieved(self):
         self._add_login_responses()
-        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "somepassword",
+        client = pybsn.connect(self.url, "admin", "somepassword",
                                                   timeout=short_timeout)
-        actual = client.get_default_timeout()
-        self.assertEqual(short_timeout, actual)
+        self.assertEqual(short_timeout, client.default_timeout)

--- a/test/test_timeout_bigdbclient_integration.py
+++ b/test/test_timeout_bigdbclient_integration.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 from itertools import repeat
 from requests.exceptions import ReadTimeout
+import urllib3
 
 import pybsn
 
@@ -10,8 +11,8 @@ from fakeserver import FakeServer, FOREVER_BLOCKING_TIME
 
 MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
 SHORT_BLOCKING_TIME = MIDDLE_BLOCKING_TIME / 2.0
-short_timeout = pybsn.TimeoutSauce(connect=SHORT_BLOCKING_TIME, read=SHORT_BLOCKING_TIME)
-long_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
+short_timeout = urllib3.util.Timeout(connect=SHORT_BLOCKING_TIME, read=SHORT_BLOCKING_TIME)
+long_timeout = urllib3.util.Timeout(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
 
 
 class SuccessfulResponse:
@@ -32,12 +33,12 @@ class TestTimeoutBigDbClientIntegration(unittest.TestCase):
     """
     server: FakeServer = None
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.server = FakeServer()
         self.server.server._testMethodName = self._testMethodName
         self.url = f"http://127.0.0.1:{self.server.port()}"
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.server.stop()
 
     def test_timeout_sauce_arg_causes_timeout(self):

--- a/test/test_timeout_bigdbclient_integration.py
+++ b/test/test_timeout_bigdbclient_integration.py
@@ -1,0 +1,87 @@
+import http.server
+import http.server
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+from http.server import HTTPServer
+from itertools import cycle, repeat
+import requests
+from requests.exceptions import ReadTimeout
+from urllib3.exceptions import ReadTimeoutError
+from unittest.mock import patch
+
+import pybsn
+
+sys.path.append("test")
+from fakeserver import FakeServer, FOREVER_BLOCKING_TIME
+
+MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
+short_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME / 2.0, read=MIDDLE_BLOCKING_TIME / 2.0)
+long_timeout = pybsn.TimeoutSauce(connect=MIDDLE_BLOCKING_TIME * 2.0, read=MIDDLE_BLOCKING_TIME * 2.0)
+
+
+class SuccessfulResponse:
+    text = '{"schema":"big"}'
+
+    def raise_for_status(self):
+        pass
+
+
+class TestTimeoutBigDbClientIntegration(unittest.TestCase):
+    """Check that actual calls using BigDbClient will timeout.
+
+       We are just checking that Session.send responds to the timeout parameter
+       as expected.  None indicates to wait forever, otherwise the TimeoutSauce
+       is used.
+
+       The pybsn code will always pass a timeout parameter.
+    """
+    server: FakeServer = None
+
+    def setUp(self) -> None:
+        self.server = FakeServer()
+        self.server.server._testMethodName = self._testMethodName
+        self.url = f"http://127.0.0.1:{self.server.port()}"
+
+    def tearDown(self) -> None:
+        self.server.stop()
+
+    def test_timeout_sauce_arg_causes_timeout(self):
+        """Verify that request.Session.Send will time out when
+           passed a TimeoutSauce.
+        """
+        self.server.start()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "a_password")
+        with self.assertRaises(ReadTimeout):
+            self.server.get_blocking(repeat(long_timeout.read_timeout, times=1))
+            client.get(self.url, timeout=short_timeout)
+
+    def test_none_waits_for_response(self):
+        """Verify that request.Session.Send will wait for a response when
+           timeout is none.
+        """
+        self.server.start()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "a_password")
+        self.server.get_blocking(repeat(long_timeout.read_timeout, times=1))
+        client.get(self.url)
+
+    def test_quick_response(self):
+        """Verify that request.Session.Send will wait process the response
+           if it arrives prior to the timeout.
+        """
+        self.server.start()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "a_password")
+        self.server.get_blocking(repeat(short_timeout.read_timeout, times=1))
+        client.get(self.url, timeout=long_timeout)
+
+    def test_quick_response(self):
+        """Verify that request.Session.Send will wait process the response
+           if it arrives prior to the timeout.
+        """
+        self.server.start()
+        client: pybsn.BigDbClient = pybsn.connect(self.url, "admin", "a_password")
+        self.server.get_blocking(repeat(short_timeout.read_timeout, times=1))
+        client.get(self.url, timeout=long_timeout)

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -10,6 +10,7 @@ from http.server import HTTPServer
 from itertools import cycle, repeat
 import requests
 import pybsn
+import urllib3
 from unittest.mock import patch
 sys.path.append("test")
 from fakeserver import FOREVER_BLOCKING_TIME, FakeServer
@@ -26,29 +27,67 @@ class TestTimeoutConnect(unittest.TestCase):
         with patch.object(requests.Session, 'send') as mock_send:
             client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
-            self.assertIsNone(client.get_default_timeout())
+            self.assertIsNone(client.default_timeout)
 
     def test_connect_timeout(self):
-        timeout = pybsn.TimeoutSauce(10, 10)
+        timeout = urllib3.util.Timeout(10, 10)
         with patch.object(requests.Session, 'send') as mock_send:
             client = pybsn.connect("http://127.0.0.1:8080",
                                    "admin", "somepassword",
                                    timeout=timeout)
             self.assertEqual(timeout, mock_send.mock_calls[0].kwargs['timeout'])
-            self.assertEqual(timeout, client.get_default_timeout())
+            self.assertEqual(timeout, client.default_timeout)
 
     def test_connect_token_default_timeout(self):
         with patch.object(requests.Session, 'send') as mock_send:
             client = pybsn.connect("http://127.0.0.1:8080", "admin",
                                    token="sometoken")
             self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
-            self.assertIsNone(client.get_default_timeout())
+            self.assertIsNone(client.default_timeout)
 
     def test_connect_token_timeout(self):
         with patch.object(requests.Session, 'send') as mock_send:
-            timeout = pybsn.TimeoutSauce(10, 10)
+            timeout = urllib3.util.Timeout(10, 10)
             client = pybsn.connect("http://127.0.0.1:8080", "admin",
                                    token="sometoken",
                                    timeout=timeout)
             self.assertEqual(timeout, mock_send.mock_calls[0].kwargs['timeout'])
-            self.assertEqual(timeout, client.get_default_timeout())
+            self.assertEqual(timeout, client.default_timeout)
+
+    def test_connect_timeout_legacy_login(self):
+        timeout = urllib3.util.Timeout(10, 10)
+
+        def has_timeout(mock_call):
+            return mock_call.kwargs['timeout'] == timeout
+
+        with patch.object(requests.Session, 'send') as mock_send:
+            first_response = requests.Response()
+            first_response.status_code = 201
+            second_response = requests.Response()
+            second_response.status_code = 200
+            mock_send.side_effect =iter( [first_response, second_response])
+            client = pybsn.connect("http://127.0.0.1:8080",
+                                   "admin", "somepassword",
+                                   timeout=timeout)
+
+            mock_send.assert_called()
+            self.assertTrue(all(has_timeout(call) for call in  mock_send.mock_calls))
+
+    def test_connect_timeout_modern_login(self):
+        timeout = urllib3.util.Timeout(10, 10)
+
+        def has_timeout(mock_call):
+            return mock_call.kwargs['timeout'] == timeout
+
+        with patch.object(requests.Session, 'send') as mock_send:
+            first_response = requests.Response()
+            first_response.status_code = 200
+            second_response = requests.Response()
+            second_response.status_code = 200
+            second_response.json = lambda : {'session-cookie':'chocolate-chip'}
+            mock_send.side_effect =iter( [first_response, second_response])
+            client = pybsn.connect("http://127.0.0.1:8080",
+                                   "admin", "somepassword",
+                                   timeout=timeout)
+            mock_send.assert_called()
+            self.assertTrue(all(has_timeout(call) for call in  mock_send.mock_calls))

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -1,0 +1,54 @@
+import http.server
+import http.server
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+from http.server import HTTPServer
+from itertools import cycle, repeat
+import requests
+import pybsn
+from unittest.mock import patch
+sys.path.append("test")
+from fakeserver import FOREVER_BLOCKING_TIME, FakeServer
+from requests import exceptions as request_exception
+
+class TestTimeoutConnect(unittest.TestCase):
+    """
+    Test that connecting to the server can timeout, and that the
+    parameter passed when connecting is used as the default value
+    for future REST operations on the session.
+    """
+
+    def test_connect_default_timeout(self):
+        with patch.object(requests.Session, 'send') as mock_send:
+            client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+            self.assertIsNone(client.get_default_timeout())
+
+    def test_connect_timeout(self):
+        timeout = pybsn.TimeoutSauce(10, 10)
+        with patch.object(requests.Session, 'send') as mock_send:
+            client = pybsn.connect("http://127.0.0.1:8080",
+                                   "admin", "somepassword",
+                                   timeout=timeout)
+            self.assertEqual(timeout, mock_send.mock_calls[0].kwargs['timeout'])
+            self.assertEqual(timeout, client.get_default_timeout())
+
+    def test_connect_token_default_timeout(self):
+        with patch.object(requests.Session, 'send') as mock_send:
+            client = pybsn.connect("http://127.0.0.1:8080", "admin",
+                                   token="sometoken")
+            self.assertIsNone(mock_send.mock_calls[0].kwargs['timeout'])
+            self.assertIsNone(client.get_default_timeout())
+
+    def test_connect_token_timeout(self):
+        with patch.object(requests.Session, 'send') as mock_send:
+            timeout = pybsn.TimeoutSauce(10, 10)
+            client = pybsn.connect("http://127.0.0.1:8080", "admin",
+                                   token="sometoken",
+                                   timeout=timeout)
+            self.assertEqual(timeout, mock_send.mock_calls[0].kwargs['timeout'])
+            self.assertEqual(timeout, client.get_default_timeout())


### PR DESCRIPTION
Have the REST operations timeout.

A timeout parameter may be passed when the sessions created.
The session timeout parameter may be changed.

REST calls may pass a timeout value.  If no value is passed then the session timeout is used.

If no timeout value is passed or set in the session, the default is to wait forever.