### PR TITLE
BSC-16713 - exclude py versions not available in ubuntu-latest (22.04)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,20 @@ jobs:
     runs-on: ${{ matrix.os-version }}
     strategy:
       matrix:
-        os-version: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        os-version: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        python-version:
+          - "3.5"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+        exclude:
+          - os-version: ubuntu-latest
+            python-version: "3.5"
+          - os-version: ubuntu-latest
+            python-version: "3.6"
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
* py 3.5, 3.6 not available for Ubuntu 22.04
* ubuntu 16.04 based images no longer available