### PR TITLE
BSC-16735 Remove support for Python 3.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os-version: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
         python-version:
-          - "3.5"
           - "3.6"
           - "3.7"
           - "3.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
    e.g., `initiate-async-id`, `async-id`
 ### Removed
 - python 2 support has been removed.
+- python 3.5 support has been removed.
 - nosetest has been removed as dependency.
 
 ## 0.3.3 - 2021-02-03

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ pybsn is a python interface to [Big Switch Network](http://bigswitch.com) produc
 ```bash
 pip3 install pybsn
 ```
-As of version 0.4.0, pybsn is only compatible with python 3.5 or newer.
+As of version 0.4.0, pybsn is only compatible with python 3.6 or newer.
 
 ---
 ## PyBSN Repl - Interactive Shell


### PR DESCRIPTION
Python 3.5 reached end of life in 2020.