### PR TITLE
BSC-16737 Deprecate useage of python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Removed
 - python 2 support has been removed.
 - python 3.5 support has been removed.
+- python 3.6 support is deprecated, and may be removed in the future.
 - nosetest has been removed as dependency.
 
 ## 0.3.3 - 2021-02-03

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ pybsn is a python interface to [Big Switch Network](http://bigswitch.com) produc
 
 ## Installation
 
+pybsn supports Python versions 3.6 to 3.11. pybsn with Python 3.6
+support has been deprecated, and may be removed in the
+next release.
+
+
 ```bash
 pip3 install pybsn
 ```


### PR DESCRIPTION
Documentation only