### PR TITLE
BSC-19699: use the logout RPC instead of delete

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -423,7 +423,7 @@ class BigDbClient(object):
         token = self.session.cookies.get_dict().get("session_cookie")
         if token:
             # This is a no-op/fine for api tokens
-            self.root.core.aaa.session.match(auth_token=token).delete()
+            self.root.core.aaa.session.logout.rpc()
 
     def _request(self, method, path, data=None, params=None, rpc=False,
                  timeout=CLIENT_TIMEOUT):


### PR DESCRIPTION
The smoke test use pybsn which uses:

self.root.core.aaa.session.match(auth_token=token).delete()

To perform a logout this is deprecated in favour of the logout
RPC:

self.root.core.aaa.session.logout.rpc()

The error is logged because of the hit on the deprecated delete,
need to move to the RPC

To test I created a PR https://github.com/bigswitch/floodlight/pull/16448/

Looking at dashboard:

https://dashboard/overview?project=seamusarista%2Ffloodlight%2Ftest-pybsn&test=atlas-cva%2Fapplication%2Fcva_sanity.py

cva_sanity.py runs successfully without hitting BUG942125

However, looking other runs of cva_sanity.py

https://dashboard/overview?test=atlas-cva%2Fapplication%2Fcva_sanity.py

we can see hits on:

BUG942125 [BSC-19699] DSR7001: session query specifying auth-token will be disallowed in the future.

[BSC-19699]: https://bigswitch.atlassian.net/browse/BSC-19699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ