### PR TITLE
BUG1108079 fix build/test issues that crept in while Github action was off

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,8 @@ jobs:
             python-version: "3.5"
           - os-version: ubuntu-latest
             python-version: "3.6"
+          - os-version: ubuntu-latest
+            python-version: "3.7"
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
         exclude:
           - os-version: ubuntu-latest
             python-version: "3.5"

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -470,13 +470,14 @@ class BigDbClient(object):
 
 def _normalize(v):
     """ Helper method to normalize query values """
-    if type(v) == bool:
+    if isinstance(v, bool):
         # replace to use booleans to use strings in JSON-boolean style
         if v:
             return "'true'"
         else:
             return "'false'"
     return repr(v)
+
 
 def logged_request(session, request, timeout):
     """ Helper method that logs HTTP requests made by this library, if configured. """

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -152,9 +152,8 @@ class TestBigDBClient(unittest.TestCase):
 
     @responses.activate
     def test_close_session(self):
-        responses.add(method=responses.DELETE,
-                      url=re.compile(r"http://127\.0\.0\.1:8080/api/v1/data/controller/core/aaa/session"
-                                     r"(?:%5B|\[)auth-token='value'(?:%5D|\])"),
+        responses.add(method=responses.POST,
+                      url="http://127.0.0.1:8080/api/v1/rpc/controller/core/aaa/session/logout",
                       status=204)
 
         self.client.session.cookies.set_cookie(
@@ -171,9 +170,8 @@ class TestBigDBClient(unittest.TestCase):
 
     @responses.activate
     def test_client_contextmanager_with_session(self):
-        responses.add(method=responses.DELETE,
-                      url=re.compile(r"http://127\.0\.0\.1:8080/api/v1/data/controller/core/aaa/session"
-                                     r"(?:%5B|\[)auth-token='value'(?:%5D|\])"),
+        responses.add(method=responses.POST,
+                      url="http://127.0.0.1:8080/api/v1/rpc/controller/core/aaa/session/logout",
                       status=204)
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/healthy",
                       status=200, json= [ { "status" : "healthy"}] )


### PR DESCRIPTION
- **BUG1108079 - exclude python 3.7 on ubuntu-latest - no longer available**
- **BUG1108079 fix flake8 warnings**
- **BUG1108079 / BSC-19699 - update test_bigdb_client to expect logout RPC**
- **BUG1108079 add py 3.12 and 3.13 to the matrix**
