### PR TITLE
BUG1108066 - urlquote values for match and filter

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import urllib.parse
 from string import Template
 from urllib.parse import urlparse
 import requests
@@ -476,7 +477,11 @@ def _normalize(v):
             return "'true'"
         else:
             return "'false'"
-    return repr(v)
+    repr_ = repr(v)
+    if repr_.startswith("'") and repr_.endswith("'"):
+        return "'" + urllib.parse.quote(repr_[1:-1]) + "'"
+    else:
+        return urllib.parse.quote(repr(v))
 
 
 def logged_request(session, request, timeout):

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -131,6 +131,10 @@ class TestNode(unittest.TestCase):
         node = self.root.node
         self.assertEqual(node.match()._path, "controller/node")
         self.assertEqual(node.match(a="foo")._path, "controller/node[a='foo']")
+        self.assertEqual(node.match(a="foo+bar")._path, "controller/node[a='foo%2Bbar']")
+        self.assertEqual(node.match(a="foo bar")._path, "controller/node[a='foo%20bar']")
+        self.assertEqual(node.match(a="foo/bar")._path, "controller/node[a='foo/bar']")
+        self.assertEqual(node.match(a=123)._path, "controller/node[a=123]")
         self.assertEqual(node.match(a=True)._path, "controller/node[a='true']")
         self.assertIn(
             node.match(a="foo", b=2)._path,


### PR DESCRIPTION
This fixes a bug, e.g., when using iso timestamps like
`2025-03-17T21:22:31.908063+00:00` in a match/filter condition. The
`+` would not get quoted and translated to a ` `.

Taking a minimal approach and keeping the quotes themselves unmatched
since has been ok and leads to more readable URLs.

Fixes: BUG1108066