### PR TITLE
BUG1108150 remove legacy login fallback

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -536,32 +536,6 @@ def _attempt_login(session, url, username, password, timeout=None):
         If successful, stores the resulting cookie in the provided requests objects.
         Raises a requests exception (e.g., requests.exceptions.HTTPError) on error.
     """
-    request = requests.Request(method="HEAD", url=url + "/api/v2/schema/controller/root/core/aaa/session/login")
-    response = logged_request(session, request, timeout=timeout)
-    if response.status_code == 200:
-        return _attempt_modern_login(session, url, username, password,
-                                     timeout=timeout)
-    else:
-        return _attempt_legacy_login(session, url, username, password,
-                                     timeout=timeout)
-
-
-def _attempt_legacy_login(session, url, username, password, timeout):
-    auth_data = json.dumps({'user': username, 'password': password})
-    path = "/api/v1/auth/login"
-    request = requests.Request(method="POST", url=url + path, data=auth_data)
-    response = logged_request(session, request, timeout=timeout)
-    if response.status_code == 200:  # OK
-        # Fix up cookie path
-        for cookie in session.cookies:
-            if cookie.path == "/auth":
-                cookie.path = "/api"
-        return url
-    else:
-        response.raise_for_status()
-
-
-def _attempt_modern_login(session, url, username, password, timeout):
     auth_data = json.dumps({'user': username, 'password': password})
     path = "/api/v1/rpc/controller/core/aaa/session/login"
     request = requests.Request(method="POST", url=url + path, data=auth_data)

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -74,28 +74,13 @@ class TestTimeoutConnect(unittest.TestCase):
             self._assertAllCallsTimeoutValue(timeout, mock_send)
             self.assertEqual(timeout, client.default_timeout)
 
-    def test_connect_timeout_legacy_login(self):
-        timeout = urllib3.util.Timeout(10, 10)
-        with patch.object(requests.Session, 'send') as mock_send:
-            first_response = requests.Response()
-            first_response.status_code = 201
-            second_response = requests.Response()
-            second_response.status_code = 200
-            mock_send.side_effect =iter( [first_response, second_response])
-            client = pybsn.connect("http://127.0.0.1:8080",
-                                   "admin", "somepassword",
-                                   timeout=timeout)
-            self._assertAllCallsTimeoutValue(timeout, mock_send)
-
     def test_connect_timeout_modern_login(self):
         timeout = urllib3.util.Timeout(10, 10)
         with patch.object(requests.Session, 'send') as mock_send:
             first_response = requests.Response()
             first_response.status_code = 200
-            second_response = requests.Response()
-            second_response.status_code = 200
-            second_response.json = lambda : {'session-cookie':'chocolate-chip'}
-            mock_send.side_effect =iter( [first_response, second_response])
+            first_response.json = lambda : {'session-cookie':'chocolate-chip'}
+            mock_send.side_effect =iter( [first_response])
             client = pybsn.connect("http://127.0.0.1:8080",
                                    "admin", "somepassword",
                                    timeout=timeout)


### PR DESCRIPTION
The modern/RPC based login was introduced in BMF 7.3 and BCF 5.3; these versions and all older versions are EoL.

Fixes: BUG1108150