### PR TITLE
BUG1284667 Bump version to 0.5.0 and require Python 3.8+

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,16 +14,12 @@ jobs:
       matrix:
         os-version: [ubuntu-22.04, ubuntu-latest]
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-        exclude:
-          - os-version: ubuntu-latest
-            python-version: "3.7"
     steps:
     - uses: actions/checkout@v2
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup
 
 setup(name='pybsn',
-    version='0.4.2',
+    version='0.5.0',
     description="pybsn is a python interface to Arista Networks BigDB/Atlas based products",
     url='https://github.com/bigswitch/pybsn',
     author='Andreas Wundsam, Andre Kutzleb, Jason Parraga, Rich Lane',
     author_email='Andreas.Wundsam@arista.com',
     license='ECLIPSE',
     packages=['pybsn'],
+    python_requires='>=3.8',
     zip_safe=False,
     install_requires=[
         "requests >= 2.3.0",


### PR DESCRIPTION
## Summary
- Updated version from 0.4.2 to 0.5.0 in setup.py
- Added python_requires='>=3.8' to setup.py
- Removed Python 3.7 from CI test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: BUG1284667