### PR TITLE
BUG1284694 Convert Python 2 examples to Python 3 and add code quality checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check
 check:
-	uv run flake8 ./pybsn/ ./bin/* --count --max-complexity=20 --max-line-length=127 --show-source --statistics
+	uv run flake8 ./pybsn/ ./bin/* ./examples/*.py ./test/*.py --count --max-complexity=20 --max-line-length=127 --show-source --statistics
 
 .PHONY: coverage
 coverage:

--- a/examples/add-static-endpoints.py
+++ b/examples/add-static-endpoints.py
@@ -18,10 +18,11 @@ import pybsn
 import argparse
 import csv
 from collections import defaultdict
+from pathlib import Path
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
-parser.add_argument('path', type=str, help="CSV file")
+parser.add_argument('path', type=Path, help="CSV file")
 parser.add_argument('--host', '-H', type=str, default="127.0.0.1", help="Controller IP/Hostname to connect to")
 parser.add_argument('--user', '-u', type=str, default="admin", help="Username")
 parser.add_argument('--password', '-p', type=str, default="adminadmin", help="Password")
@@ -47,5 +48,5 @@ with open(args.path) as f:
         })
 
 for ((tenant, segment), endpoints) in sorted(endpoints_by_segment.items()):
-    print("Adding %d static endpoints to tenant %s segment %s" % (len(endpoints), tenant, segment))
+    print(f"Adding {len(endpoints)} static endpoints to tenant {tenant} segment {segment}")
     bcf.root.applications.bcf.tenant.match(name=tenant).segment.match(name=segment).endpoint.put(endpoints)

--- a/examples/add-static-endpoints.py
+++ b/examples/add-static-endpoints.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
-parser.add_argument('path', type=file, help="CSV file")
+parser.add_argument('path', type=str, help="CSV file")
 parser.add_argument('--host', '-H', type=str, default="127.0.0.1", help="Controller IP/Hostname to connect to")
 parser.add_argument('--user', '-u', type=str, default="admin", help="Username")
 parser.add_argument('--password', '-p', type=str, default="adminadmin", help="Password")
@@ -33,18 +33,19 @@ bcf = pybsn.connect(args.host, args.user, args.password)
 # (tenant, segment) -> [endpoint]
 endpoints_by_segment = defaultdict(list)
 
-for row in csv.reader(args.path):
-    tenant, segment, name, mac, switch, interface, vlan = row
-    endpoints_by_segment[(tenant, segment)].append({
-        'name': name,
-        'mac': mac,
-        'attachment-point': {
-            'switch': switch,
-            'interface': interface,
-            'vlan': vlan,
-        }
-    })
+with open(args.path) as f:
+    for row in csv.reader(f):
+        tenant, segment, name, mac, switch, interface, vlan = row
+        endpoints_by_segment[(tenant, segment)].append({
+            'name': name,
+            'mac': mac,
+            'attachment-point': {
+                'switch': switch,
+                'interface': interface,
+                'vlan': vlan,
+            }
+        })
 
 for ((tenant, segment), endpoints) in sorted(endpoints_by_segment.items()):
-    print "Adding %d static endpoints to tenant %s segment %s" % (len(endpoints), tenant, segment)
+    print("Adding %d static endpoints to tenant %s segment %s" % (len(endpoints), tenant, segment))
     bcf.root.applications.bcf.tenant.match(name=tenant).segment.match(name=segment).endpoint.put(endpoints)

--- a/examples/bigtap-hostdiff.py
+++ b/examples/bigtap-hostdiff.py
@@ -23,7 +23,6 @@ bt = pybsn.connect(args.host, args.user, args.password)
 hosts = bt.root.applications.bigtap.tracked_host()
 
 new_data = []
-import random
 for host in hosts:
     new_data.append(Host(
         ip=host['ip-addr'],
@@ -42,21 +41,23 @@ new_set = set(new_data)
 
 deleted_hosts = []
 for host in old_data:
-    if not host in new_set:
+    if host not in new_set:
         deleted_hosts.append(host)
 
 added_hosts = []
 for host in new_data:
-    if not host in old_set:
+    if host not in old_set:
         added_hosts.append(host)
+
 
 def ip_sort_key(host):
     return socket.inet_aton(host.ip)
 
+
 diff_hosts = sorted(deleted_hosts + added_hosts, key=ip_sort_key)
 for host in diff_hosts:
-    mark = host in new_set and '+' or '-'
-    print "%s %-15s %s %s" % (mark, host.ip, host.mac, host.hostname)
+    mark = '+' if host in new_set else '-'
+    print("%s %-15s %s %s" % (mark, host.ip, host.mac, host.hostname))
 
 with open(TMP_FILENAME, "w") as f:
     pickle.dump(new_data, f)

--- a/examples/bigtap-interface-errors.py
+++ b/examples/bigtap-interface-errors.py
@@ -24,8 +24,10 @@ switches_by_dpid = {}
 for switch in bt.root.core.switch():
     switches_by_dpid[switch['dpid']] = switch
 
+
 def atoi(text):
     return int(text) if text.isdigit() else text
+
 
 def natural_keys(text):
     '''
@@ -33,19 +35,21 @@ def natural_keys(text):
     http://nedbatchelder.com/blog/200712/human_sorting.html
     (See Toothy's implementation in the comments)
     '''
-    return [ atoi(c) for c in re.split('(\d+)', text) ]
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
+
 
 def sort_key(interface):
     return (interface['switch'], natural_keys(interface['interface']))
 
+
 for interface in sorted(interfaces, key=sort_key):
     if interface['count-rx-error'] > 0 or interface['count-xmit-error'] > 0:
-        direction = interface['direction'] == "rx" and "<-" or "->"
+        direction = "<-" if interface['direction'] == "rx" else "->"
         if interface['switch'] in switches_by_dpid:
             switch_name = switches_by_dpid[interface['switch']]['alias']
         else:
             switch_name = interface['switch']
-        print switch_name, interface['interface'], interface['type'], direction, interface['peer']
+        print(switch_name, interface['interface'], interface['type'], direction, interface['peer'])
         for k, v in interface.items():
             if re.match(r'count.*error', k) and v > 0:
-                print "  %s: %u" % (k, v)
+                print("  %s: %u" % (k, v))

--- a/examples/bigtap-tshark.py
+++ b/examples/bigtap-tshark.py
@@ -8,9 +8,13 @@ import signal
 import os
 
 finished = False
+
+
 def sigint(signal, frame):
     global finished
     finished = True
+
+
 signal.signal(signal.SIGINT, sigint)
 
 parser = argparse.ArgumentParser(description='Display captured traffic in realtime')
@@ -35,12 +39,12 @@ now = int(time.time())
 name = 'tshark-%d' % now
 policy = policies.match(name=name)
 
-print "Installing policy", name
+print("Installing policy", name)
 
 policy.put({
     'name': name,
     'action': 'capture',
-    'priority' : args.priority,
+    'priority': args.priority,
 })
 
 policy.filter_group.match(name=args.filter_interface).put({
@@ -67,7 +71,7 @@ policy.patch({
 })
 
 try:
-    print "Waiting for policy to be applied"
+    print("Waiting for policy to be applied")
 
     while not finished:
         events = policy.policy_history.match(policy_event="installation complete")()
@@ -78,7 +82,7 @@ try:
                 break
         time.sleep(0.5)
 
-    print "Capturing packets"
+    print("Capturing packets")
 
     if 'tshark' in args.tool:
         tool_args = ['-i-']
@@ -92,7 +96,7 @@ try:
     try:
         offset = 0
         while not finished:
-            r = bt.session.get(url, stream=True, headers={ 'Range': 'bytes=%d-' % offset })
+            r = bt.session.get(url, stream=True, headers={'Range': 'bytes=%d-' % offset})
             if r.status_code == 416:
                 time.sleep(1.0)
                 continue

--- a/examples/schema-reserved-words.py
+++ b/examples/schema-reserved-words.py
@@ -20,12 +20,14 @@ blacklist = set(dir(bcf.root) + keyword.kwlist)
 seen = set()
 failed = False
 
+
 def traverse(node, path):
-    name = 'name' in node and node['name'] or None
+    global failed
+    name = node['name'] if 'name' in node else None
     if name and name not in seen:
         seen.add(name)
         if name in blacklist or '_' in name:
-            print name, node['nodeType'], "at", path
+            print(name, node['nodeType'], "at", path)
             failed = True
 
     if node['nodeType'] == 'CONTAINER' or node['nodeType'] == 'LIST_ELEMENT':
@@ -33,6 +35,7 @@ def traverse(node, path):
             traverse(child, path + "/" + child_name)
     elif node['nodeType'] == 'LIST':
         traverse(node['listElementSchemaNode'], path)
+
 
 traverse(bcf.schema('controller'), 'controller')
 

--- a/examples/schema-reserved-words.py
+++ b/examples/schema-reserved-words.py
@@ -23,7 +23,7 @@ failed = False
 
 def traverse(node, path):
     global failed
-    name = node['name'] if 'name' in node else None
+    name = node.get('name')
     if name and name not in seen:
         seen.add(name)
         if name in blacklist or '_' in name:

--- a/examples/schema-spelling.py
+++ b/examples/schema-spelling.py
@@ -17,6 +17,7 @@ bcf = pybsn.connect(args.host, args.user, args.password)
 names = []
 descriptions = []
 
+
 def traverse(node):
     if 'name' in node:
         names.append(node['name'])
@@ -29,6 +30,7 @@ def traverse(node):
             traverse(child)
     elif node['nodeType'] == 'LIST':
         traverse(node['listElementSchemaNode'])
+
 
 traverse(bcf.root.schema())
 
@@ -45,4 +47,4 @@ for err in chkr:
         description_errors.add(chkr.word)
 
 for word in sorted(description_errors):
-    print word
+    print(word)

--- a/examples/support-bundle.py
+++ b/examples/support-bundle.py
@@ -14,13 +14,13 @@ args = parser.parse_args()
 
 bcf = pybsn.connect(args.host, args.user, args.password)
 
-print "Generating..."
-reply = root.support.generate_bundle.rpc()
-print "Downloading..."
+print("Generating...")
+reply = bcf.root.support.generate_bundle.rpc()
+print("Downloading...")
 name = args.output or reply['name']
-with open(name, "w") as f:
+with open(name, "wb") as f:
     r = bcf.session.get(bcf.url + reply['url-path'], stream=True)
     r.raise_for_status()
     for chunk in r.iter_content(4096):
         f.write(chunk)
-print "Support bundle left in", name
+print("Support bundle left in", name)

--- a/examples/viewdebugcounters.py
+++ b/examples/viewdebugcounters.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-#!/usr/bin/env python
+# This program displays the debug counters exposed by all switches in
+# the fabric in real time. Counters with zero values are not shown.
+from collections import namedtuple
+import npyscreen
+import time
+import argparse
+import pybsn
 help = """
-This program displays the debug counters exposed by all switches in
-the fabric in real time. Counters with zero values are not shown.
-
 Keybindings:
 
   '?' - this message
@@ -17,11 +20,6 @@ Keybindings:
   'z' - zero counters
   'Z' - unzero counters (show absolute values)
 """
-import pybsn
-import argparse
-import time
-import npyscreen
-from collections import namedtuple
 
 parser = argparse.ArgumentParser(description='View debug counters for all switches')
 
@@ -34,9 +32,11 @@ args = parser.parse_args()
 
 bcf = pybsn.connect(args.host, args.user, args.password)
 
+
 class DebugCounter(namedtuple("DebugCounter",
-        ["name", "description", "value", "initial_value"])):
+                              ["name", "description", "value", "initial_value"])):
     pass
+
 
 class DebugCounterSource(object):
     def __init__(self, bcf):
@@ -71,12 +71,14 @@ class DebugCounterSource(object):
             if c.value != c.initial_value:
                 yield c
 
+
 class DebugCounterList(npyscreen.MultiLine):
     def __init__(self, *args, **keywords):
         super(DebugCounterList, self).__init__(*args, **keywords)
 
     def display_value(self, v):
         return "%s: %d" % (v.name, v.value - v.initial_value)
+
 
 class DebugCounterForm(npyscreen.FormBaseNew):
     FRAMED = False
@@ -148,11 +150,14 @@ class DebugCounterForm(npyscreen.FormBaseNew):
     def handle_help(self, ch):
         self.h_display_help(ch)
 
+
 class ViewDebugCountersApp(npyscreen.NPSAppManaged):
     keypress_timeout_default = 3
+
     def onStart(self):
         source = DebugCounterSource(bcf)
         self.addForm("MAIN", DebugCounterForm, source=source)
+
 
 if __name__ == "__main__":
     App = ViewDebugCountersApp()

--- a/examples/watch-debug-events.py
+++ b/examples/watch-debug-events.py
@@ -18,8 +18,10 @@ MAX_EVENT_RATE = 10
 ctrl = pybsn.connect(args.host, args.user, args.password)
 events = ctrl.root.core.controller.debugeventinfo.event
 
+
 def sort_key(x):
     return -x['event-instance-id']
+
 
 latest_id_by_name = {}
 
@@ -45,6 +47,6 @@ while True:
             initial_indent='  ',
             subsequent_indent='  ',
             width=78)
-        print event['timestamp'], event['mod-event-name'], description
+        print(event['timestamp'], event['mod-event-name'], description)
 
     time.sleep(0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ Repository = "https://github.com/bigswitch/pybsn"
 [tool.setuptools]
 packages = ["pybsn"]
 script-files = ["bin/pybsn-repl", "bin/pybsn-schema"]
+
+[dependency-groups]
+dev = [
+    "autopep8>=2.0.0",
+]

--- a/test/fakeserver.py
+++ b/test/fakeserver.py
@@ -3,7 +3,7 @@ import threading
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from itertools import repeat
-from typing import Iterable
+from typing import Iterable  # noqa: F401
 
 # How long to wait in seconds before sending a response in a test
 # case where we are checking that we will wait forever.
@@ -24,7 +24,7 @@ class BlockingServer(HTTPServer):
     def __init__(self, server_address, RequestHandlerClass):
         super().__init__(server_address, RequestHandlerClass)
 
-    def is_stopped(self) :
+    def is_stopped(self):
         """
         :returns: boolean
         """
@@ -40,14 +40,14 @@ class BlockingServer(HTTPServer):
 class FakeHandler(BaseHTTPRequestHandler):
     """Override the server type from BaseServer."""
 
-    def _server(self) :
+    def _server(self):
         """Casting self.server for Python checking.
         :return: BlockingServer
         """
         # noinspection PyTypeChecker
         return self.server
 
-    def _block(self, delay_list) :
+    def _block(self, delay_list):
         """Delay for a period of time.
 
         Attributes:
@@ -179,7 +179,6 @@ class FakeServer:
            :parameter delay Amount of seconds to wait. Iterable[float]
         """
         self.server.get_blocking = delay
-
 
     def start(self):
         # noinspection PyBroadException

--- a/test/mockutils.py
+++ b/test/mockutils.py
@@ -6,9 +6,8 @@ def get_mockcall_attribute(mock_call, name):
     Python 3.6 version of:
             self.assertIsNone(mock_call.kwargs['name'])
     """
-    for part_index in range(0, len(mock_call)):
-        if isinstance(mock_call[part_index], dict):
-            kwargs = mock_call[part_index]
-            if name in kwargs:
-                return kwargs[name]
+    for part in mock_call:
+        if isinstance(part, dict):
+            if name in part:
+                return part[name]
     raise Exception("named attribute not found: " + name)

--- a/test/mockutils.py
+++ b/test/mockutils.py
@@ -6,10 +6,9 @@ def get_mockcall_attribute(mock_call, name):
     Python 3.6 version of:
             self.assertIsNone(mock_call.kwargs['name'])
     """
-    for part_index in range(0,len(mock_call)):
-        if type(mock_call[part_index]) == dict:
+    for part_index in range(0, len(mock_call)):
+        if isinstance(mock_call[part_index], dict):
             kwargs = mock_call[part_index]
             if name in kwargs:
                 return kwargs[name]
     raise Exception("named attribute not found: " + name)
-

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -35,7 +35,7 @@ class TestBigDBClient(unittest.TestCase):
                                callback=self._login_cb,
                                content_type="application/json")
 
-        _ = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+        pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
 
     @responses.activate
     def test_close_no_auth(self):

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -1,7 +1,6 @@
 import json
 import os
 import logging
-import re
 import unittest
 from unittest.mock import patch
 import requests
@@ -36,7 +35,7 @@ class TestBigDBClient(unittest.TestCase):
                                callback=self._login_cb,
                                content_type="application/json")
 
-        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+        _ = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
 
     @responses.activate
     def test_close_no_auth(self):
@@ -48,7 +47,7 @@ class TestBigDBClient(unittest.TestCase):
             self.assertEqual(json.loads(req.body), {'user': 'admin', 'password': 'foo'})
             headers = {
             }
-            return (401, headers, json.dumps({"description":"Invalid user/password combination.","error-code":401}))
+            return (401, headers, json.dumps({"description": "Invalid user/password combination.", "error-code": 401}))
 
         responses.add_callback(responses.POST,
                                "http://127.0.0.1:8080/api/v1/rpc/controller/core/aaa/session/login",
@@ -63,9 +62,9 @@ class TestBigDBClient(unittest.TestCase):
     def test_connect_token(self):
         def _aaa_cb(req):
             self.assertEqual(req.headers["Cookie"], "session_cookie=some_token")
-            return (200, {}, json.dumps([ {  "auth-context-type" : "session-token",  "user-info" :
-                              {   "full-name" : "Default admin",
-                             "group" : [ "admin" ],    "user-name" : "admin"  } } ])
+            return (200, {}, json.dumps([{"auth-context-type": "session-token",  "user-info":
+                                          {"full-name": "Default admin",
+                                           "group": ["admin"],    "user-name": "admin"}}])
                     )
 
         responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/aaa/auth-context",
@@ -73,15 +72,14 @@ class TestBigDBClient(unittest.TestCase):
 
         pybsn.connect("http://127.0.0.1:8080", token="some_token")
 
-
     @responses.activate
     def test_connect_token_custom_headers(self):
         def _aaa_cb(req):
             self.assertEqual(req.headers["Cookie"], "session_cookie=some_token")
             self.assertEqual(req.headers["X-Forwarded-For"], "1.2.3.4")
-            return (200, {}, json.dumps([ {  "auth-context-type" : "session-token",  "user-info" :
-                              {   "full-name" : "Default admin",
-                             "group" : [ "admin" ],    "user-name" : "admin"  } } ])
+            return (200, {}, json.dumps([{"auth-context-type": "session-token",  "user-info":
+                                          {"full-name": "Default admin",
+                                           "group": ["admin"],    "user-name": "admin"}}])
                     )
 
         responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/aaa/auth-context",
@@ -94,8 +92,8 @@ class TestBigDBClient(unittest.TestCase):
         def _aaa_cb(req):
             self.assertEqual(req.headers["Cookie"], "session_cookie=wrong_token")
             return (401, {}, json.dumps({
-                "description":"Authorization failed: No session or token found for cookie",
-                "error-code":401
+                "description": "Authorization failed: No session or token found for cookie",
+                "error-code": 401
             }))
 
         responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/aaa/auth-context",
@@ -106,7 +104,7 @@ class TestBigDBClient(unittest.TestCase):
         self.assertEqual(context.exception.response.status_code, 401)
 
     @responses.activate
-    def test_close_no_auth(self):
+    def test_close_no_auth_no_request(self):
         # no request
         self.client.close()
 
@@ -123,7 +121,7 @@ class TestBigDBClient(unittest.TestCase):
     @responses.activate
     def test_client_contextmanager(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/healthy",
-                      status=200, json= [ { "status" : "healthy"}] )
+                      status=200, json=[{"status": "healthy"}])
 
         with pybsn.connect("http://127.0.0.1:8080") as client:
             client.get("controller/core/healthy")
@@ -134,7 +132,7 @@ class TestBigDBClient(unittest.TestCase):
                       url="http://127.0.0.1:8080/api/v1/rpc/controller/core/aaa/session/logout",
                       status=204)
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/healthy",
-                      status=200, json= [ { "status" : "healthy"}] )
+                      status=200, json=[{"status": "healthy"}])
 
         with pybsn.connect("http://127.0.0.1:8080") as client:
             client.session.cookies.set_cookie(
@@ -144,16 +142,16 @@ class TestBigDBClient(unittest.TestCase):
     @responses.activate
     def test_get(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/test",
-                      json={'state': "ok" }, status=200)
+                      json={'state': "ok"}, status=200)
         result = self.client.get(path="controller/test")
-        self.assertEqual(result, {'state':"ok"})
+        self.assertEqual(result, {'state': "ok"})
 
     @responses.activate
     def test_get_with_param(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/test?state-type=global-config",
-                      json={'state': "ok" }, status=200)
+                      json={'state': "ok"}, status=200)
         result = self.client.get(path="controller/test", params={'state-type': 'global-config'})
-        self.assertEqual(result, {'state':"ok"})
+        self.assertEqual(result, {'state': "ok"})
 
     @responses.activate
     def _mutate_test(self, response_type, method_name, add_params=False):
@@ -162,7 +160,6 @@ class TestBigDBClient(unittest.TestCase):
             return (204, {}, None)
 
         expected_url = "http://127.0.0.1:8080/api/v1/data/controller/test"
-        path = "controller/test"
 
         if add_params:
             expected_url += "?state-type=global-config"
@@ -191,7 +188,7 @@ class TestBigDBClient(unittest.TestCase):
     @responses.activate
     def test_delete_with_param(self):
         responses.add(responses.DELETE, "http://127.0.0.1:8080/api/v1/data/controller/test?state-type=global-config",
-                    status=204)
+                      status=204)
         self.client.delete(path="controller/test", params={'state-type': 'global-config'})
 
     @responses.activate
@@ -222,21 +219,21 @@ class TestBigDBClient(unittest.TestCase):
     @responses.activate
     def test_schema(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/schema/",
-                      json={'state': "ok" }, status=200)
+                      json={'state': "ok"}, status=200)
         result = self.client.schema()
-        self.assertEqual(result, {'state':"ok"})
+        self.assertEqual(result, {'state': "ok"})
 
     @responses.activate
     def test_schema_with_path(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/schema/foo",
-                      json={'state': "ok" }, status=200)
+                      json={'state': "ok"}, status=200)
         result = self.client.schema(path="foo")
-        self.assertEqual(result, {'state':"ok"})
+        self.assertEqual(result, {'state': "ok"})
 
     @responses.activate
     def test_schema_failed(self):
         responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/schema/",
-                      json={'state': "ok" }, status=404)
+                      json={'state': "ok"}, status=404)
         with self.assertRaises(requests.exceptions.HTTPError):
             self.client.schema()
 
@@ -246,6 +243,6 @@ class TestBigDBClient(unittest.TestCase):
             mock_is_enabled.return_value = True
             with patch.object(logging.Logger, "debug") as mock_debug:
                 responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/schema/",
-                      json={'state': "ok" }, status=200)
+                              json={'state': "ok"}, status=200)
                 self.client.schema()
                 mock_debug.assert_called()

--- a/test/test_timeout_bigdbclient.py
+++ b/test/test_timeout_bigdbclient.py
@@ -9,8 +9,8 @@ import urllib3
 import pybsn
 
 sys.path.append("test")
-from fakeserver import FOREVER_BLOCKING_TIME
-from mockutils import get_mockcall_attribute
+from fakeserver import FOREVER_BLOCKING_TIME  # noqa: E402
+from mockutils import get_mockcall_attribute  # noqa: E402
 
 MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
 SHORT_BLOCKING_TIME = MIDDLE_BLOCKING_TIME / 2.0
@@ -24,7 +24,6 @@ class SuccessfulResponse:
 
     def raise_for_status(self):
         pass
-
 
 
 class TestTimeoutBigDbClient(unittest.TestCase):

--- a/test/test_timeout_bigdbclient_integration.py
+++ b/test/test_timeout_bigdbclient_integration.py
@@ -7,7 +7,7 @@ import urllib3
 import pybsn
 
 sys.path.append("test")
-from fakeserver import FakeServer, FOREVER_BLOCKING_TIME
+from fakeserver import FakeServer, FOREVER_BLOCKING_TIME  # noqa: E402
 
 MIDDLE_BLOCKING_TIME = FOREVER_BLOCKING_TIME / 2.0
 SHORT_BLOCKING_TIME = MIDDLE_BLOCKING_TIME / 2.0

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -1,21 +1,12 @@
-import http.server
-import http.server
-import json
-import os
 import sys
-import threading
-import time
 import unittest
-from http.server import HTTPServer
-from itertools import cycle, repeat
 import requests
-from requests import exceptions as request_exception
 import pybsn
 import urllib3
 from unittest.mock import patch
 sys.path.append("test")
-from fakeserver import FOREVER_BLOCKING_TIME, FakeServer
-from mockutils import get_mockcall_attribute
+from mockutils import get_mockcall_attribute  # noqa: E402
+
 
 class TestTimeoutConnect(unittest.TestCase):
     """
@@ -34,6 +25,7 @@ class TestTimeoutConnect(unittest.TestCase):
            have a timeout argument set to the expected value.
         """
         mock_function.assert_called()
+
         def compare_value(call):
             if call[0].startswith('().'):
                 # Not a REST call ignore.
@@ -79,9 +71,9 @@ class TestTimeoutConnect(unittest.TestCase):
         with patch.object(requests.Session, 'send') as mock_send:
             first_response = requests.Response()
             first_response.status_code = 200
-            first_response.json = lambda : {'session-cookie':'chocolate-chip'}
-            mock_send.side_effect =iter( [first_response])
-            client = pybsn.connect("http://127.0.0.1:8080",
-                                   "admin", "somepassword",
-                                   timeout=timeout)
+            first_response.json = lambda: {'session-cookie': 'chocolate-chip'}
+            mock_send.side_effect = iter([first_response])
+            _ = pybsn.connect("http://127.0.0.1:8080",
+                              "admin", "somepassword",
+                              timeout=timeout)
             self._assertAllCallsTimeoutValue(timeout, mock_send)

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -73,7 +73,7 @@ class TestTimeoutConnect(unittest.TestCase):
             first_response.status_code = 200
             first_response.json = lambda: {'session-cookie': 'chocolate-chip'}
             mock_send.side_effect = iter([first_response])
-            _ = pybsn.connect("http://127.0.0.1:8080",
-                              "admin", "somepassword",
-                              timeout=timeout)
+            pybsn.connect("http://127.0.0.1:8080",
+                          "admin", "somepassword",
+                          timeout=timeout)
             self._assertAllCallsTimeoutValue(timeout, mock_send)

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,56 @@ wheels = [
 ]
 
 [[package]]
+name = "autopep8"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "pycodestyle", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "tomli", marker = "python_full_version < '3.8.1'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/71/48b7fde78ef09f4636a9b81f926b879d0230f90768483c441f22059d2474/autopep8-2.0.0.tar.gz", hash = "sha256:8b1659c7f003e693199f52caffdc06585bb0716900bbc6a7442fd931d658c077", size = 117507 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/c0/a1372bd95578778aae8dc5359e4f8ec03a94479d2f36e30543298d30c48a/autopep8-2.0.0-py2.py3-none-any.whl", hash = "sha256:ad924b42c2e27a1ac58e432166cc4588f5b80747de02d0d35b1ecbd3e7d57207", size = 45410 },
+]
+
+[[package]]
+name = "autopep8"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "pycodestyle", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/52/65556a5f917a4b273fd1b705f98687a6bd721dbc45966f0f6687e90a18b0/autopep8-2.3.1.tar.gz", hash = "sha256:8d6c87eba648fdcfc83e29b788910b8643171c395d9c4bcf115ece035b9c9dda", size = 92064 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/9e/f0beffe45b507dca9d7540fad42b316b2fd1076dc484c9b1f23d9da570d7/autopep8-2.3.1-py2.py3-none-any.whl", hash = "sha256:a203fe0fcad7939987422140ab17a930f684763bf7335bdb6709991dd7ef6c2d", size = 45667 },
+]
+
+[[package]]
+name = "autopep8"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "pycodestyle", version = "2.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807 },
+]
+
+[[package]]
 name = "backcall"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -668,6 +718,13 @@ test = [
     { name = "responses" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "autopep8", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "autopep8", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "autopep8", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -680,6 +737,9 @@ requires-dist = [
     { name = "traitlets", specifier = ">=4.3.3" },
 ]
 provides-extras = ["test", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "autopep8", specifier = ">=2.0.0" }]
 
 [[package]]
 name = "pycodestyle"
@@ -913,6 +973,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]


### PR DESCRIPTION
Sits on top of #375 

## Summary

Convert all example scripts from Python 2 to Python 3 and add comprehensive code quality checks to the build process.

### Python 2 to Python 3 Conversion
- Convert all `print` statements to `print()` functions in examples/
- Fix Python 2 style conditionals (`and/or` → ternary operators)
- Update argparse file handling (`file` → `str` type with proper `open()` calls)
- Add proper file context managers (`with open()`)
- Fix bug in `support-bundle.py` (was missing `bcf.` prefix on `root`)

### Code Quality Improvements
- **Makefile**: Extended `check` target to lint `examples/` and `test/` directories
- **autopep8**: Added as dev dependency for minimal PEP 8 fixes
- **Test fixes**: Cleaned up unused imports, fixed duplicate function names, improved type checks
- **Style fixes**: Ran autopep8 to automatically fix all remaining whitespace/formatting issues

### Results
- ✅ All 84 tests pass
- ✅ `make check` passes with 0 flake8 errors
- ✅ Examples are now Python 3 compatible and included in quality checks

This creates a clean baseline before introducing Black formatting in future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: BUG1284694