### PR TITLE
BUG1821559 Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -5,26 +5,27 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - '*' # Trigger when any tag is pushed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
+    name: Create GitHub release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # Required for `gh release create`.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Get release version from setup.py
-        id: get_version
-        # extract the version value string from the setup.py file (tag value does not matter)
-        run: echo RELEASE_VERSION=$(cat setup.py | grep version | grep -o "'.*'" | sed "s/'//g") >> $GITHUB_ENV
-
-      - name: Create Github Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: ${{ env.RELEASE_VERSION }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
+          persist-credentials: false
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --notes-from-tag

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -2,39 +2,51 @@ name: Release on PyPi
 on:
   workflow_dispatch: # Allows this workflow to be manually triggered
     inputs:
-      twineRepo: # User input can override default pypi repo, e.g. using 'testpypi'
-        description: 'Target Twine Repository for Release'
+      repository:
+        description: 'Target PyPI repository for release'
         required: true
-        default: 'pypi'
+        type: choice
+        default: pypi
+        options:
+          - pypi
+          - testpypi
   push:
     tags:
       - '*' # Trigger when any tag is pushed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Build and publish distributions
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # Required for PyPI trusted publishing.
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: false
 
-    - name: Choose Twine Repository
-      run: |
-        if [ -z "${{ github.event.inputs.twineRepo }}" ]; then
-            echo TWINE_REPO=pypi >> $GITHUB_ENV
-        else
-            echo TWINE_REPO="${{ github.event.inputs.twineRepo }}" >> $GITHUB_ENV
-        fi
+    - name: Build distributions
+      run: uv build
 
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        uv build
-        uvx twine upload --repository "${{ env.TWINE_REPO }}" dist/*
+    - name: Publish distributions
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      with:
+        repository-url: ${{ github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,8 +7,17 @@ on:
     branches: [ main ]
   schedule:
     - cron: "0 0 * * *" # At the end of every day
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Test (${{ matrix.os-version }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
       matrix:
@@ -21,15 +30,17 @@ jobs:
           - "3.12"
           - "3.13"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
Summary:
- Pin workflow actions to full commit SHAs and add Dependabot updates for GitHub Actions.
- Set least-privilege workflow permissions and disable checkout credential persistence.
- Replace PyPI username/password upload with trusted publishing and remove shell interpolation of manual release input.
- Replace the archived create-release action with gh release create.

Testing:
- uvx zizmor --pedantic .github/workflows
- actionlint .github/workflows/*.yml
- ruby YAML load for workflow and Dependabot files
- make lint check test

AI-Assisted-By: Codex (gpt-5.4)
Fixes: BUG1821559