### PR TITLE
Retry idempotent requests on transport abort per RFC 9110

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ fix:
 
 .PHONY: coverage
 coverage:
-	uv run coverage run --omit */*-packages/* -m unittest discover -v
+	uv run --extra test coverage run --omit */*-packages/* -m unittest discover -v
 
 .PHONY: coverage-report
 coverage-report:
-	uv run coverage report
+	uv run --extra test coverage report
 
 .PHONY: install-deps
 install-deps:
@@ -42,4 +42,4 @@ reformat:
 
 .PHONY: test
 test:
-	uv run --with .[test] python -m unittest discover -v
+	uv run --extra test python -m unittest discover -v

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -3,13 +3,14 @@ import logging
 import re
 import urllib.parse
 import warnings
+from http.client import RemoteDisconnected
 from string import Template
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import requests
 import urllib3.util
-from urllib3.exceptions import InsecureRequestWarning
+from urllib3.exceptions import InsecureRequestWarning, ProtocolError
 
 warnings.simplefilter("ignore", InsecureRequestWarning)
 
@@ -521,6 +522,20 @@ def _normalize(v: Any) -> str:
         return urllib.parse.quote(repr(v))
 
 
+_IDEMPOTENT_METHODS = frozenset({"DELETE", "GET", "HEAD", "OPTIONS", "PUT"})
+
+
+def _is_retryable_connection_error(exc: requests.exceptions.ConnectionError) -> bool:
+    """Match a stale keep-alive connection closed before any response bytes arrive.
+
+    Per RFC 9110 Section 9.2.2, an idempotent request can be retried after
+    a communication failure before the response is read.
+    """
+    if not exc.args or not isinstance(protocol_error := exc.args[0], ProtocolError):
+        return False
+    return any(isinstance(arg, RemoteDisconnected) for arg in protocol_error.args)
+
+
 def logged_request(
     session: requests.Session, request: requests.Request, timeout: Optional[Union[float, urllib3.util.Timeout]]
 ) -> requests.Response:
@@ -538,7 +553,15 @@ def logged_request(
             prepared.body,
         )
 
-    response = session.send(prepared, timeout=timeout)  # type: ignore[arg-type]
+    try:
+        response = session.send(prepared, timeout=timeout)  # type: ignore[arg-type]
+    except requests.exceptions.ConnectionError as e:
+        if prepared.method in _IDEMPOTENT_METHODS and _is_retryable_connection_error(e):
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Retrying %s %s after transport abort", prepared.method, prepared.url)
+            response = session.send(prepared, timeout=timeout)  # type: ignore[arg-type]
+        else:
+            raise
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(

--- a/test/closingserver.py
+++ b/test/closingserver.py
@@ -1,0 +1,146 @@
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+QueuedAction = Tuple[Union[str, int], Optional[bytes], Optional[Dict[str, str]]]
+RequestRecord = Dict[str, Any]
+
+
+class ClosingServer(HTTPServer):
+    thread: Optional[threading.Thread]
+
+    def __init__(self, server_address: Tuple[str, int] = ("127.0.0.1", 0)) -> None:
+        super().__init__(server_address, ClosingHandler)
+        self._actions: List[QueuedAction] = []
+        self._requests: List[RequestRecord] = []
+        self._lock = threading.Lock()
+        self.thread = None
+
+    def queue_drop_next_request(self) -> None:
+        with self._lock:
+            self._actions.append(("drop_next_request", None, None))
+
+    def queue_close_with_last_response(self) -> None:
+        with self._lock:
+            self._actions.append(("close_with_last_response", None, None))
+
+    def queue_json(self, payload: Any, status: int = 200) -> None:
+        body = json.dumps(payload).encode("utf8")
+        response_headers = {"Content-Type": "application/json"}
+        self.queue_response(status=status, body=body, headers=response_headers)
+
+    def queue_response(self, status: int = 200, body: bytes = b"", headers: Optional[Dict[str, str]] = None) -> None:
+        with self._lock:
+            self._actions.append((status, body, headers or {}))
+
+    def next_action(self) -> QueuedAction:
+        with self._lock:
+            if not self._actions:
+                raise Exception("No queued action for test server")
+            return self._actions.pop(0)
+
+    def consume_close_with_last_response(self) -> bool:
+        with self._lock:
+            if self._actions and self._actions[0][0] == "close_with_last_response":
+                self._actions.pop(0)
+                return True
+            return False
+
+    def record_request(self, method: str, path: str, connection_id: Any) -> None:
+        with self._lock:
+            self._requests.append({"connection_id": connection_id, "method": method, "path": path})
+
+    def requests(self) -> List[RequestRecord]:
+        with self._lock:
+            return list(self._requests)
+
+    def request_count(self) -> int:
+        with self._lock:
+            return len(self._requests)
+
+    def start(self) -> bool:
+        try:
+            self.thread = threading.Thread(name="ClosingServer", target=self.serve_forever)
+            self.thread.start()
+            return True
+        except Exception:
+            print(f"unable to start server on port {self.server_port}")
+            return False
+
+    def port(self) -> int:
+        return self.server_port
+
+    def stop(self) -> None:
+        if self.thread and self.thread.is_alive():
+            self.shutdown()
+        if self.thread:
+            self.thread.join(timeout=60)
+            if self.thread.is_alive():
+                raise Exception("Server thread did not terminate")
+        self.server_close()
+
+
+class ClosingHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            return self.rfile.read(length)
+        return b""
+
+    def _handle(self) -> None:
+        self._read_body()
+        self.server.record_request(self.command, self.path, self.client_address)
+
+        action = self.server.next_action()
+        if action[0] == "drop_next_request":
+            self.close_connection = True
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+            return
+
+        status, response_body, headers = action
+        assert isinstance(status, int)
+        assert response_body is not None
+        assert headers is not None
+        should_close_with_last_response = self.server.consume_close_with_last_response()
+        self.send_response(status)
+        if should_close_with_last_response:
+            self.send_header("Connection", "close")
+        for key, value in headers.items():
+            self.send_header(key, value)
+        if "Content-Length" not in headers:
+            self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        if response_body:
+            self.wfile.write(response_body)
+            self.wfile.flush()
+        if should_close_with_last_response:
+            self.close_connection = True
+            try:
+                self.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                # The client may have already closed its side after reading the response.
+                pass
+            self.connection.close()
+
+    def do_DELETE(self) -> None:
+        self._handle()
+
+    def do_GET(self) -> None:
+        self._handle()
+
+    def do_POST(self) -> None:
+        self._handle()
+
+    def do_PATCH(self) -> None:
+        self._handle()
+
+    def do_PUT(self) -> None:
+        self._handle()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -2,10 +2,12 @@ import json
 import logging
 import os
 import unittest
+from http.client import RemoteDisconnected
 from unittest.mock import patch
 
 import requests
 import responses
+from urllib3.exceptions import ProtocolError
 
 import pybsn
 
@@ -283,3 +285,70 @@ class TestBigDBClient(unittest.TestCase):
                 responses.add(responses.GET, "http://127.0.0.1:8080/api/v1/schema/", json={"state": "ok"}, status=200)
                 self.client.schema()
                 mock_debug.assert_called()
+
+
+class TestTransportRetry(unittest.TestCase):
+    URL = "http://127.0.0.1:8080/api/v1/data/controller/test"
+
+    def setUp(self):
+        self.client = pybsn.connect("http://127.0.0.1:8080")
+
+    def _premature_close_error(self):
+        return requests.exceptions.ConnectionError(
+            ProtocolError(
+                "Connection aborted.",
+                RemoteDisconnected("Remote end closed connection without response"),
+            )
+        )
+
+    def _call_method(self, method):
+        fn = getattr(self.client, method.lower())
+        if method in ("GET", "DELETE"):
+            return fn(path="controller/test")
+        return fn(path="controller/test", data={"foo": "bar"})
+
+    def _assert_idempotent_method_retries_once_on_protocol_error(self, method):
+        responses.add(method, self.URL, body=self._premature_close_error())
+        responses.add(method, self.URL, json={"state": "ok"}, status=200)
+
+        self._call_method(method)
+
+        self.assertEqual(2, len(responses.calls), f"{method} should have retried once")
+
+    @responses.activate
+    def test_idempotent_methods_retry_on_protocol_error(self):
+        for method in (responses.GET, responses.PUT, responses.DELETE):
+            with self.subTest(method=method):
+                responses.reset()
+                self._assert_idempotent_method_retries_once_on_protocol_error(method)
+
+    @responses.activate
+    def test_post_does_not_retry_on_protocol_error(self):
+        responses.add(responses.POST, self.URL, body=self._premature_close_error())
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.client.post(path="controller/test", data={"foo": "bar"})
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_patch_does_not_retry_on_protocol_error(self):
+        responses.add(responses.PATCH, self.URL, body=self._premature_close_error())
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.client.patch(path="controller/test", data={"foo": "bar"})
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_no_retry_on_connection_refused_reraises_original_exception(self):
+        error = requests.exceptions.ConnectionError("Connection refused")
+        responses.add(responses.GET, self.URL, body=error)
+        with self.assertRaises(requests.exceptions.ConnectionError) as context:
+            self.client.get(path="controller/test")
+        self.assertIs(context.exception, error)
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_retry_fails_twice_raises(self):
+        responses.add(responses.GET, self.URL, body=self._premature_close_error())
+        responses.add(responses.GET, self.URL, body=self._premature_close_error())
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.client.get(path="controller/test")
+        self.assertEqual(len(responses.calls), 2)

--- a/test/test_premature_close_integration.py
+++ b/test/test_premature_close_integration.py
@@ -1,0 +1,120 @@
+import unittest
+from test.closingserver import ClosingServer
+
+import requests
+
+import pybsn
+
+
+class TestPrematureCloseIntegration(unittest.TestCase):
+    def setUp(self):
+        self.server = ClosingServer()
+        self.assertTrue(self.server.start())
+        self.url = f"http://127.0.0.1:{self.server.port()}"
+
+    def tearDown(self):
+        self.server.stop()
+
+    def _call_method(self, client, method):
+        fn = getattr(client, method.lower())
+        if method in ("GET", "DELETE"):
+            return fn("controller/test")
+        return fn("controller/test", data={"foo": "bar"})
+
+    def _assert_idempotent_method_retries_after_keep_alive_premature_close(self, method):
+        self.server.queue_json({"state": "warmup"})
+        self.server.queue_drop_next_request()
+        self.server.queue_json({"state": "ok"})
+        self.server.queue_close_with_last_response()
+
+        client = pybsn.connect(self.url)
+
+        self.assertEqual({"state": "warmup"}, client.get("controller/test"))
+        result = self._call_method(client, method)
+        if method == "GET":
+            self.assertEqual({"state": "ok"}, result)
+        else:
+            self.assertEqual(200, result.status_code)
+
+        requests_log = self.server.requests()
+        self.assertEqual(3, self.server.request_count(), msg=f"unexpected request log: {requests_log}")
+        self.assertEqual(
+            [
+                ("GET", "/api/v1/data/controller/test"),
+                (method, "/api/v1/data/controller/test"),
+                (method, "/api/v1/data/controller/test"),
+            ],
+            [(request["method"], request["path"]) for request in requests_log],
+            msg=f"unexpected request log: {requests_log}",
+        )
+        self.assertEqual(
+            requests_log[0]["connection_id"],
+            requests_log[1]["connection_id"],
+            msg=f"expected keep-alive reuse before retry: {requests_log}",
+        )
+        self.assertNotEqual(
+            requests_log[1]["connection_id"],
+            requests_log[2]["connection_id"],
+            msg=f"expected retry on a new TCP connection: {requests_log}",
+        )
+
+    def test_get_retries_after_keep_alive_premature_close(self):
+        self._assert_idempotent_method_retries_after_keep_alive_premature_close("GET")
+
+    def test_put_retries_after_keep_alive_premature_close(self):
+        self._assert_idempotent_method_retries_after_keep_alive_premature_close("PUT")
+
+    def test_delete_retries_after_keep_alive_premature_close(self):
+        self._assert_idempotent_method_retries_after_keep_alive_premature_close("DELETE")
+
+    def test_post_does_not_retry_after_keep_alive_premature_close(self):
+        self.server.queue_json({"state": "warmup"})
+        self.server.queue_drop_next_request()
+
+        client = pybsn.connect(self.url)
+
+        self.assertEqual({"state": "warmup"}, client.get("controller/test"))
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            client.post("controller/test", data={"foo": "bar"})
+
+        requests_log = self.server.requests()
+        self.assertEqual(2, self.server.request_count(), msg=f"unexpected request log: {requests_log}")
+        self.assertEqual(
+            [
+                ("GET", "/api/v1/data/controller/test"),
+                ("POST", "/api/v1/data/controller/test"),
+            ],
+            [(request["method"], request["path"]) for request in requests_log],
+            msg=f"unexpected request log: {requests_log}",
+        )
+        self.assertEqual(
+            requests_log[0]["connection_id"],
+            requests_log[1]["connection_id"],
+            msg=f"expected stale keep-alive POST to arrive on the reused socket: {requests_log}",
+        )
+
+    def test_patch_does_not_retry_after_keep_alive_premature_close(self):
+        self.server.queue_json({"state": "warmup"})
+        self.server.queue_drop_next_request()
+
+        client = pybsn.connect(self.url)
+
+        self.assertEqual({"state": "warmup"}, client.get("controller/test"))
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            client.patch("controller/test", data={"foo": "bar"})
+
+        requests_log = self.server.requests()
+        self.assertEqual(2, self.server.request_count(), msg=f"unexpected request log: {requests_log}")
+        self.assertEqual(
+            [
+                ("GET", "/api/v1/data/controller/test"),
+                ("PATCH", "/api/v1/data/controller/test"),
+            ],
+            [(request["method"], request["path"]) for request in requests_log],
+            msg=f"unexpected request log: {requests_log}",
+        )
+        self.assertEqual(
+            requests_log[0]["connection_id"],
+            requests_log[1]["connection_id"],
+            msg=f"expected stale keep-alive PATCH to arrive on the reused socket: {requests_log}",
+        )


### PR DESCRIPTION
Retry idempotent requests on transport abort per RFC 9110

AI-Assisted-By: Codex (gpt-5.4)