### PR TITLE
BUG1413418: Enable pybsn to connect to port 443 with the /a/api prefix

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -583,23 +583,25 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
 
     # Parse schema-less URL to detect explicit port (host:port) or path prefix (host/prefix)
     parsed = urlparse(f"//{host}")
-    if parsed.port is not None:
-        # User specified explicit port — use it directly, derive schema from port convention
-        scheme = "https" if parsed.port in (443, 8443) else "http"
-        prefix = parsed.path
-        if not prefix:
-            matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
-            prefix = matching_endpoint.prefix if matching_endpoint is not None else ""
-        candidates = [(scheme, parsed.hostname, parsed.port, prefix)]
-    elif parsed.path:
-        # User specified a path prefix but no port — probe all ports with the custom prefix
-        candidates = [(e.scheme, parsed.hostname, e.port_no, parsed.path) for e in BIGDB_PROTO_PORTS]
-    else:
-        # Bare hostname — probe all ports with their configured prefixes
-        candidates = [(e.scheme, host, e.port_no, e.prefix) for e in BIGDB_PROTO_PORTS]
+    hostname = parsed.hostname or host
+    path_prefix = parsed.path
+    endpoints = BIGDB_PROTO_PORTS
 
-    for scheme, hostname, port, prefix in candidates:
-        url = f"{scheme}://{hostname}:{port}{prefix}"
+    if parsed.port is not None:
+        # An explicit port was specified — use it directly, derive scheme from port convention
+        matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
+        endpoints = [
+            ApiEndpointConfig(
+                scheme=matching_endpoint.scheme if matching_endpoint is not None else "https" if parsed.port in (443, 8443) else "http",
+                port_no=parsed.port,
+                prefix=path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else ""),
+            )
+        ]
+        path_prefix = ""
+
+    for endpoint in endpoints:
+        prefix = path_prefix or endpoint.prefix
+        url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{prefix}"
         try:
             response = session.get(url + validate_path, timeout=2)
         except requests.exceptions.ConnectionError as e:

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -590,11 +590,16 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     if parsed.port is not None:
         # An explicit port was specified — use it directly, derive scheme from port convention
         matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
+        if matching_endpoint is not None:
+            scheme = matching_endpoint.scheme
+        else:
+            scheme = "https" if parsed.port in (443, 8443) else "http"
+        prefix = path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else "")
         endpoints = [
             ApiEndpointConfig(
-                scheme=matching_endpoint.scheme if matching_endpoint is not None else "https" if parsed.port in (443, 8443) else "http",
+                scheme=scheme,
                 port_no=parsed.port,
-                prefix=path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else ""),
+                prefix=prefix,
             )
         ]
         path_prefix = ""

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -581,7 +581,7 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     if re.match(r"^https?://", host):
         return host
 
-    # Parse schema-less URL to detect explicit port (host:port) or path prefix (host/prefix)
+    # Parse a URL without a scheme to detect explicit port (host:port) or path prefix (host/prefix)
     parsed = urlparse(f"//{host}")
     hostname = parsed.hostname or host
     path_prefix = parsed.path

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -559,15 +559,15 @@ API_PREFIX = "/a"
 
 @dataclass(frozen=True)
 class ApiEndpointConfig:
-    schema: str
+    scheme: str
     port_no: int
     prefix: str
 
 
 BIGDB_PROTO_PORTS = [
-    ApiEndpointConfig(schema="https", port_no=443, prefix=API_PREFIX),
-    ApiEndpointConfig(schema="https", port_no=8443, prefix=""),
-    ApiEndpointConfig(schema="http", port_no=8080, prefix=""),
+    ApiEndpointConfig(scheme="https", port_no=443, prefix=API_PREFIX),
+    ApiEndpointConfig(scheme="https", port_no=8443, prefix=""),
+    ApiEndpointConfig(scheme="http", port_no=8080, prefix=""),
 ]
 
 
@@ -585,17 +585,21 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     parsed = urlparse(f"//{host}")
     if parsed.port is not None:
         # User specified explicit port — use it directly, derive schema from port convention
-        schema = "https" if parsed.port in (443, 8443) else "http"
-        candidates = [(schema, parsed.hostname, parsed.port, parsed.path)]
+        scheme = "https" if parsed.port in (443, 8443) else "http"
+        prefix = parsed.path
+        if not prefix:
+            matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
+            prefix = matching_endpoint.prefix if matching_endpoint is not None else ""
+        candidates = [(scheme, parsed.hostname, parsed.port, prefix)]
     elif parsed.path:
         # User specified a path prefix but no port — probe all ports with the custom prefix
-        candidates = [(e.schema, parsed.hostname, e.port_no, parsed.path) for e in BIGDB_PROTO_PORTS]
+        candidates = [(e.scheme, parsed.hostname, e.port_no, parsed.path) for e in BIGDB_PROTO_PORTS]
     else:
         # Bare hostname — probe all ports with their configured prefixes
-        candidates = [(e.schema, host, e.port_no, e.prefix) for e in BIGDB_PROTO_PORTS]
+        candidates = [(e.scheme, host, e.port_no, e.prefix) for e in BIGDB_PROTO_PORTS]
 
-    for schema, hostname, port, prefix in candidates:
-        url = f"{schema}://{hostname}:{port}{prefix}"
+    for scheme, hostname, port, prefix in candidates:
+        url = f"{scheme}://{hostname}:{port}{prefix}"
         try:
             response = session.get(url + validate_path, timeout=2)
         except requests.exceptions.ConnectionError as e:
@@ -631,12 +635,13 @@ def _attempt_login(
 
     # If we reach here, status is 2xx (typically 200 for login endpoint)
     json_ = response.json()
-    url_path_prefix = urlparse(url).path.rstrip("/")
+    parsed_url = urlparse(url)
+    url_path_prefix = parsed_url.path.rstrip("/")
     session_cookie_path = f"{url_path_prefix}/api" if url_path_prefix else "/api"
     session_cookie = requests.cookies.create_cookie(
         name="session_cookie",
         value=json_["session-cookie"],
-        domain=urlparse(url).hostname,
+        domain=parsed_url.hostname,
         path=session_cookie_path,  # type: ignore[arg-type]
     )
     session.cookies.set_cookie(session_cookie)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -3,6 +3,7 @@ import logging
 import re
 import urllib.parse
 import warnings
+from dataclasses import dataclass
 from string import Template
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -553,9 +554,20 @@ def logged_request(
     return response
 
 
+API_PREFIX = "/a"
+
+
+@dataclass(frozen=True)
+class ApiEndpointConfig:
+    schema: str
+    port_no: int
+    prefix: str
+
+
 BIGDB_PROTO_PORTS = [
-    ("https", 8443),
-    ("http", 8080),
+    ApiEndpointConfig(schema="https", port_no=443, prefix=API_PREFIX),
+    ApiEndpointConfig(schema="https", port_no=8443, prefix=""),
+    ApiEndpointConfig(schema="http", port_no=8080, prefix=""),
 ]
 
 
@@ -568,18 +580,31 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     """
     if re.match(r"^https?://", host):
         return host
+
+    # Parse schema-less URL to detect explicit port (host:port) or path prefix (host/prefix)
+    parsed = urlparse(f"//{host}")
+    if parsed.port is not None:
+        # User specified explicit port — use it directly, derive schema from port convention
+        schema = "https" if parsed.port in (443, 8443) else "http"
+        candidates = [(schema, parsed.hostname, parsed.port, parsed.path)]
+    elif parsed.path:
+        # User specified a path prefix but no port — probe all ports with the custom prefix
+        candidates = [(e.schema, parsed.hostname, e.port_no, parsed.path) for e in BIGDB_PROTO_PORTS]
     else:
-        for schema, port in BIGDB_PROTO_PORTS:
-            url = "%s://%s:%d" % (schema, host, port)
-            try:
-                response = session.get(url + validate_path, timeout=2)
-            except requests.exceptions.ConnectionError as e:
-                logger.debug("Error connecting to %s: %s", url, str(e))
-                continue
-            if response.status_code == 200:  # OK
-                return url
-            else:
-                logger.debug("Could connect to URL %s: %s", url, response)
+        # Bare hostname — probe all ports with their configured prefixes
+        candidates = [(e.schema, host, e.port_no, e.prefix) for e in BIGDB_PROTO_PORTS]
+
+    for schema, hostname, port, prefix in candidates:
+        url = f"{schema}://{hostname}:{port}{prefix}"
+        try:
+            response = session.get(url + validate_path, timeout=2)
+        except requests.exceptions.ConnectionError as e:
+            logger.debug("Error connecting to %s: %s", url, str(e))
+            continue
+        if response.status_code == 200:  # OK
+            return url
+        else:
+            logger.debug("Could connect to URL %s: %s", url, response)
     raise Exception("Could not find available BigDB service on {}".format(host))
 
 
@@ -606,8 +631,13 @@ def _attempt_login(
 
     # If we reach here, status is 2xx (typically 200 for login endpoint)
     json_ = response.json()
+    url_path_prefix = urlparse(url).path.rstrip("/")
+    session_cookie_path = f"{url_path_prefix}/api" if url_path_prefix else "/api"
     session_cookie = requests.cookies.create_cookie(
-        name="session_cookie", value=json_["session-cookie"], domain=urlparse(url).hostname, path="/api"  # type: ignore[arg-type]
+        name="session_cookie",
+        value=json_["session-cookie"],
+        domain=urlparse(url).hostname,
+        path=session_cookie_path,  # type: ignore[arg-type]
     )
     session.cookies.set_cookie(session_cookie)
     return url

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -47,6 +47,29 @@ class TestBigDBClient(unittest.TestCase):
         pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
 
     @responses.activate
+    def test_connect_modern_login_port_443_prefix(self):
+        def _data_cb(req):
+            self.assertEqual(req.headers["Cookie"], "session_cookie=UPhNWlmDN0re8cg9xsqe9QT1QvQTznji")
+            return (200, {}, json.dumps({"state": "ok"}))
+
+        responses.add(responses.GET, "https://127.0.0.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add_callback(
+            responses.POST,
+            "https://127.0.0.1:443/a/api/v1/rpc/controller/core/aaa/session/login",
+            callback=self._login_cb,
+            content_type="application/json",
+        )
+        responses.add_callback(
+            responses.GET,
+            "https://127.0.0.1:443/a/api/v1/data/controller/test",
+            callback=_data_cb,
+            content_type="application/json",
+        )
+
+        client = pybsn.connect("127.0.0.1", "admin", "somepassword")
+        self.assertEqual(client.get("controller/test"), {"state": "ok"})
+
+    @responses.activate
     def test_close_no_auth(self):
         self.client.close()
 

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -1,0 +1,311 @@
+"""Tests for port 443 with /a prefix support
+
+These include:
+1. Port 443 with /a prefix discovery
+2. Fallback behavior when port 443 is unavailable
+3. Prefix is correctly applied only to port 443
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+import responses
+
+import pybsn
+
+
+class TestGuessUrlFallback(unittest.TestCase):
+    """Test the guess_url() function's port discovery and fallback logic."""
+
+    @responses.activate
+    def test_port_443_with_prefix_tried_first(self):
+        """Port 443 with /a prefix should be tried first."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_fallback_to_8443_when_443_unavailable(self):
+        """Should fallback to port 8443 when 443 is not available."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_fallback_to_8080_when_443_and_8443_unavailable(self):
+        """Should fallback to port 8080 when both 443 and 8443 fail."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "http://192.0.2.1:8080")
+        self.assertEqual(len(responses.calls), 3)
+
+    @responses.activate
+    def test_non_200_response_causes_fallback(self):
+        """Non-200 responses should cause fallback to next port."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=404)
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+
+    @responses.activate
+    def test_exception_when_all_ports_fail(self):
+        """Should raise exception when all ports fail."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+
+        session = requests.Session()
+        with self.assertRaises(Exception) as context:
+            pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertIn("Could not find available BigDB service", str(context.exception))
+
+    @responses.activate
+    def test_complete_url_bypasses_discovery(self):
+        """Complete URLs should be returned as-is without port probing."""
+        session = requests.Session()
+
+        url = pybsn.guess_url(session, "https://192.0.2.1:8443")
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 0)
+
+
+class TestPort443PrefixApplication(unittest.TestCase):
+    """Test that /a prefix is correctly applied only to port 443."""
+
+    @responses.activate
+    def test_prefix_applied_to_port_443(self):
+        """The /a prefix should be included in all requests to port 443."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request includes /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertIn("/a/api/v1/data/", data_call.request.url)
+
+    @responses.activate
+    def test_prefix_not_applied_to_port_8443(self):
+        """The /a prefix should NOT be included in requests to port 8443."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request does NOT include /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertNotIn("/a/", data_call.request.url)
+        self.assertEqual(data_call.request.url, "https://192.0.2.1:8443/api/v1/data/controller/core/switch")
+
+    @responses.activate
+    def test_prefix_not_applied_to_port_8080(self):
+        """The /a prefix should NOT be included in requests to port 8080."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request does NOT include /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertNotIn("/a/", data_call.request.url)
+        self.assertEqual(data_call.request.url, "http://192.0.2.1:8080/api/v1/data/controller/core/switch")
+
+    @responses.activate
+    def test_all_request_types_include_prefix_on_443(self):
+        """All request types (data, rpc, schema) should include /a prefix on port 443."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/data/controller/core/switch", json=[], status=200)
+        responses.add(
+            responses.POST, "https://192.0.2.1:443/a/api/v1/rpc/controller/test/action", json={"result": "ok"}, status=200
+        )
+        responses.add(
+            responses.GET, "https://192.0.2.1:443/a/api/v1/schema/controller/core/switch", json={"type": "object"}, status=200
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+        client.rpc("controller/test/action", {})
+        client.schema("controller/core/switch")
+
+        # Verify all requests include /a prefix
+        for call in responses.calls[1:]:  # Skip the healthy check
+            self.assertIn(
+                "/a/api/v1/",
+                call.request.url,
+                f"Request {call.request.url} should include /a prefix",
+            )
+
+
+class TestSchemalessUrl(unittest.TestCase):
+    """Test handling of schema-less URLs with explicit port or path prefix."""
+
+    @responses.activate
+    def test_explicit_port_uses_https(self):
+        """host:8443 should use https and only probe that port."""
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:8443")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_443_uses_https(self):
+        """host:443 should use https and only probe that port."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:443/a")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_8080_uses_http(self):
+        """host:8080 should use http and only probe that port."""
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:8080")
+
+        self.assertEqual(url, "http://192.0.2.1:8080")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_custom_path_prefix_probes_all_ports(self):
+        """host/custom-prefix should probe all ports with that prefix."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/custom/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/custom/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1/custom")
+
+        self.assertEqual(url, "https://192.0.2.1:8443/custom")
+        self.assertEqual(len(responses.calls), 2)
+
+
+class TestFallbackTiming(unittest.TestCase):
+    """Test fallback timeout behavior."""
+
+    def test_timeout_is_2_seconds(self):
+        """Verify the timeout for each port probe is 2 seconds."""
+        session = requests.Session()
+
+        with patch.object(session, "get") as mock_get:
+            mock_get.side_effect = [
+                Mock(status_code=404),
+                Mock(status_code=200),
+            ]
+
+            pybsn.guess_url(session, "192.0.2.1")
+
+            # Each call should have timeout=2
+            for call in mock_get.call_args_list:
+                self.assertEqual(call[1].get("timeout"), 2)
+
+    def test_fallback_order_is_correct(self):
+        """Verify ports are tried in order: 443, 8443, 8080."""
+        session = requests.Session()
+
+        with patch.object(session, "get") as mock_get:
+            mock_get.side_effect = [
+                Mock(status_code=404),  # 443 fails
+                Mock(status_code=404),  # 8443 fails
+                Mock(status_code=200),  # 8080 succeeds
+            ]
+
+            pybsn.guess_url(session, "192.0.2.1")
+
+            # Extract URLs from calls
+            urls = [call[0][0] for call in mock_get.call_args_list]
+
+            self.assertIn("443", urls[0], "First attempt should be port 443")
+            self.assertIn(pybsn.API_PREFIX, urls[0], "Port 443 should include /a prefix")
+            self.assertIn("8443", urls[1], "Second attempt should be port 8443")
+            self.assertNotIn("/a/", urls[1], "Port 8443 should NOT include /a prefix")
+            self.assertIn("8080", urls[2], "Third attempt should be port 8080")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -227,8 +227,19 @@ class TestSchemalessUrl(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
-    def test_explicit_port_443_uses_https(self):
-        """host:443 should use https and only probe that port."""
+    def test_explicit_port_443_without_prefix_uses_default_prefix(self):
+        """host:443 should use https and the default /a prefix."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:443")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_443_with_prefix_uses_https(self):
+        """host:443/a should use https and only probe that port."""
         responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
 
         session = requests.Session()


### PR DESCRIPTION
Enables pybsn to automatically discover and connect to BigDB services that have been migrated to port 443 with the /a/api prefix
This PR is a follow-up after the previous PR ran into a bug. pybsn was updated to discover the new REST base URL on
port 443 as https://<host>:443/a, but login still created the session cookie with path /api. That meant login could
succeed, while the next authenticated request to /a/api/... failed with 401 because the cookie was not sent. In CVML
this showed up as repeated pybsn client NOT connected polling until timeout.

This change derives the session cookie path from the base URL path prefix, so https://<host>:443/a uses /a/api while
legacy URLs like https://<host>:443 and https://<host>:8443 continue to use /api.

Tested with unit tests and against a CVML controller with a custom script written using codex to utilise the new pybsn
to make a GET request to the controller:

  - old reverted version resolved `https://10.226.78.185:443/a`, set cookie path /api, and failed the first authenticated
    GET with 401
  - this version resolved `https://10.226.78.185:443/a`, set cookie path /a/api, and the same authenticated GET
    succeeded

Fixes: BUG1413418