### PR TITLE
BUG1413418: Prevent false positives on health checks

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -3,6 +3,7 @@ import logging
 import re
 import urllib.parse
 import warnings
+from dataclasses import dataclass
 from string import Template
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -553,9 +554,20 @@ def logged_request(
     return response
 
 
+API_PREFIX = "/a"
+
+
+@dataclass(frozen=True)
+class ApiEndpointConfig:
+    scheme: str
+    port_no: int
+    prefix: str
+
+
 BIGDB_PROTO_PORTS = [
-    ("https", 8443),
-    ("http", 8080),
+    ApiEndpointConfig(scheme="https", port_no=443, prefix=API_PREFIX),
+    ApiEndpointConfig(scheme="https", port_no=8443, prefix=""),
+    ApiEndpointConfig(scheme="http", port_no=8080, prefix=""),
 ]
 
 
@@ -568,18 +580,42 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     """
     if re.match(r"^https?://", host):
         return host
-    else:
-        for schema, port in BIGDB_PROTO_PORTS:
-            url = "%s://%s:%d" % (schema, host, port)
-            try:
-                response = session.get(url + validate_path, timeout=2)
-            except requests.exceptions.ConnectionError as e:
-                logger.debug("Error connecting to %s: %s", url, str(e))
-                continue
-            if response.status_code == 200:  # OK
-                return url
-            else:
-                logger.debug("Could connect to URL %s: %s", url, response)
+
+    # Parse a URL without a scheme to detect explicit port (host:port) or path prefix (host/prefix)
+    parsed = urlparse(f"//{host}")
+    hostname = parsed.hostname or host
+    path_prefix = parsed.path
+    endpoints = BIGDB_PROTO_PORTS
+
+    if parsed.port is not None:
+        # An explicit port was specified — use it directly, derive scheme from port convention
+        matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
+        if matching_endpoint is not None:
+            scheme = matching_endpoint.scheme
+        else:
+            scheme = "https" if parsed.port in (443, 8443) else "http"
+        prefix = path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else "")
+        endpoints = [
+            ApiEndpointConfig(
+                scheme=scheme,
+                port_no=parsed.port,
+                prefix=prefix,
+            )
+        ]
+        path_prefix = ""
+
+    for endpoint in endpoints:
+        prefix = path_prefix or endpoint.prefix
+        url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{prefix}"
+        try:
+            response = session.get(url + validate_path, timeout=2)
+        except requests.exceptions.ConnectionError as e:
+            logger.debug("Error connecting to %s: %s", url, str(e))
+            continue
+        if response.status_code == 200:  # OK
+            return url
+        else:
+            logger.debug("Could connect to URL %s: %s", url, response)
     raise Exception("Could not find available BigDB service on {}".format(host))
 
 
@@ -606,8 +642,14 @@ def _attempt_login(
 
     # If we reach here, status is 2xx (typically 200 for login endpoint)
     json_ = response.json()
+    parsed_url = urlparse(url)
+    url_path_prefix = parsed_url.path.rstrip("/")
+    session_cookie_path = f"{url_path_prefix}/api" if url_path_prefix else "/api"
     session_cookie = requests.cookies.create_cookie(
-        name="session_cookie", value=json_["session-cookie"], domain=urlparse(url).hostname, path="/api"  # type: ignore[arg-type]
+        name="session_cookie",
+        value=json_["session-cookie"],
+        domain=parsed_url.hostname,
+        path=session_cookie_path,  # type: ignore[arg-type]
     )
     session.cookies.set_cookie(session_cookie)
     return url

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -572,7 +572,7 @@ BIGDB_PROTO_PORTS = [
 ]
 
 
-def _is_valid_probe_response(response: requests.Response) -> bool:
+def _is_valid_probe_response(url: str, response: requests.Response) -> bool:
     """Return True when a probe response confirms the endpoint is really BigDB.
 
     Older controllers can return GUI HTML with HTTP 200 for probe paths that are
@@ -580,10 +580,14 @@ def _is_valid_probe_response(response: requests.Response) -> bool:
     catch-all pages are rejected regardless of the validation path in use.
     """
     if response.status_code != 200:
+        logger.debug("Probe to %s returned status %d; skipping", url, response.status_code)
         return False
 
     content_type = response.headers.get("Content-Type", "")
-    return content_type.lower().startswith("application/json")
+    if content_type.lower().startswith("application/json"):
+        return True
+    logger.debug("Probe to %s returned 200 but unexpected Content-Type %r; skipping", url, content_type)
+    return False
 
 
 def _normalize_path_prefix(path_prefix: str) -> str:
@@ -631,10 +635,8 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             logger.debug("Error connecting to %s: %s", url, str(e))
             continue
-        if _is_valid_probe_response(response):
+        if _is_valid_probe_response(url + validate_path, response):
             return url
-        else:
-            logger.debug("Could connect to URL %s: %s", url, response)
     raise Exception("Could not find available BigDB service on {}".format(host))
 
 

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -1,5 +1,5 @@
-import json
 import ipaddress
+import json
 import logging
 import re
 import urllib.parse

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -572,20 +572,18 @@ BIGDB_PROTO_PORTS = [
 ]
 
 
-def _is_valid_probe_response(response: requests.Response, validate_path: str) -> bool:
+def _is_valid_probe_response(response: requests.Response) -> bool:
     """Return True when a probe response confirms the endpoint is really BigDB.
 
-    The default auth health probe is vulnerable to GUI catch-all routes returning
-    HTML with HTTP 200 on older controllers. Only accept that probe when the body
-    is the expected boolean payload.
+    Older controllers can return GUI HTML with HTTP 200 for probe paths that are
+    not actually backed by BigDB. Accept only JSON probe responses so HTML
+    catch-all pages are rejected regardless of the validation path in use.
     """
     if response.status_code != 200:
         return False
 
-    if validate_path == "/api/v1/auth/healthy":
-        return response.text.strip().lower() in {"true", "false"}
-
-    return True
+    content_type = response.headers.get("Content-Type", "")
+    return content_type.lower().startswith("application/json")
 
 
 def _normalize_path_prefix(path_prefix: str) -> str:
@@ -649,7 +647,7 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             logger.debug("Error connecting to %s: %s", url, str(e))
             continue
-        if _is_valid_probe_response(response, validate_path):
+        if _is_valid_probe_response(response):
             return url
         else:
             logger.debug("Could connect to URL %s: %s", url, response)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -573,7 +573,7 @@ BIGDB_PROTO_PORTS = [
 
 
 def _is_valid_probe_response(url: str, response: requests.Response) -> bool:
-    """Return True when a probe response confirms the endpoint is really BigDB.
+    """Return True when a probe response is a usable BigDB success response.
 
     Older controllers can return GUI HTML with HTTP 200 for probe paths that are
     not actually backed by BigDB. Accept only JSON probe responses so HTML
@@ -583,22 +583,14 @@ def _is_valid_probe_response(url: str, response: requests.Response) -> bool:
         logger.debug("Probe to %s returned status %d; skipping", url, response.status_code)
         return False
 
-    content_type = response.headers.get("Content-Type", "")
-    if content_type.lower().startswith("application/json"):
+    content_type, *_ct_params = response.headers.get("Content-Type", "").split(";", maxsplit=1)
+    if content_type.lower().strip() == "application/json":
         return True
-    logger.debug("Probe to %s returned 200 but unexpected Content-Type %r; skipping", url, content_type)
+    logger.debug("Probe to %s returned 200 but unexpected Content-Type %r; skipping", url, response.headers.get("Content-Type", ""))
     return False
 
 
-def _normalize_path_prefix(path_prefix: str) -> str:
-    if not path_prefix or path_prefix == "/":
-        return ""
-    if path_prefix.endswith("/"):
-        path_prefix = path_prefix[:-1]
-    return path_prefix if path_prefix.startswith("/") else f"/{path_prefix}"
-
-
-def _format_url_authority(hostname: str) -> str:
+def _format_url_host(hostname: str) -> str:
     try:
         address = ipaddress.ip_address(hostname)
     except ValueError:
@@ -610,26 +602,28 @@ def _format_url_authority(hostname: str) -> str:
 def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v1/auth/healthy") -> str:
     """Guess the correct BigDB URL for a given host if not specified completely.
     :param session: requests session to use
-    :param host: host as specified by the user
+    :param host: host as specified by the user. Scheme-less inputs stay in discovery
+                 mode and must not include an explicit port or custom path prefix.
+                 Explicit endpoints must be provided as full URLs with scheme.
     :param validate_path: BigDB path to use to validate the correctness of the guess
     :return fully qualified BigDB URL
     """
     if re.match(r"^https?://", host):
         return host
 
-    # Parse a URL without a scheme to detect an optional path prefix (host/prefix).
+    # Parse a URL without a scheme to detect invalid explicit ports or path prefixes.
     parsed = urlparse(f"//{host}")
     hostname = parsed.hostname
     if hostname is None:
         raise ValueError(f"Could not parse host from {host!r}")
     if parsed.port is not None:
         raise ValueError(f"Schemeless hosts must not include an explicit port: {host!r}")
-    hostname = _format_url_authority(hostname)
-    path_prefix = _normalize_path_prefix(parsed.path)
+    if parsed.path not in ("", "/"):
+        raise ValueError(f"Schemeless hosts must not include a path prefix: {host!r}")
+    hostname = _format_url_host(hostname)
 
     for endpoint in BIGDB_PROTO_PORTS:
-        prefix = path_prefix or endpoint.prefix
-        url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{prefix}"
+        url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{endpoint.prefix}"
         try:
             response = session.get(url + validate_path, timeout=2)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
@@ -665,7 +659,7 @@ def _attempt_login(
     json_ = response.json()
     parsed_url = urlparse(url)
     url_path_prefix = parsed_url.path.rstrip("/")
-    session_cookie_path = f"{url_path_prefix}/api" if url_path_prefix else "/api"
+    session_cookie_path = f"{url_path_prefix}/api"
     session_cookie = requests.cookies.create_cookie(
         name="session_cookie",
         value=json_["session-cookie"],
@@ -690,8 +684,9 @@ def connect(
 
     Main entrypoint to pybsn.
 
-    :param host: BigDB Host to connect to; can be just the hostname/IP (1.2.3.4) or the BigDB URL
-                 prefix (https://1.2.3.4:8443/)
+    :param host: BigDB host to connect to. This can be a bare hostname/IP for endpoint
+                 discovery (for example 1.2.3.4 or [2001:db8::1]), or a full BigDB URL
+                 such as https://1.2.3.4:8443/ or https://controller.example/custom.
 
     To use user/password authentication (interactive session):
     :parameter username

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -613,33 +613,17 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
     if re.match(r"^https?://", host):
         return host
 
-    # Parse a URL without a scheme to detect explicit port (host:port) or path prefix (host/prefix)
+    # Parse a URL without a scheme to detect an optional path prefix (host/prefix).
     parsed = urlparse(f"//{host}")
     hostname = parsed.hostname
     if hostname is None:
         raise ValueError(f"Could not parse host from {host!r}")
+    if parsed.port is not None:
+        raise ValueError(f"Schemeless hosts must not include an explicit port: {host!r}")
     hostname = _format_url_authority(hostname)
     path_prefix = _normalize_path_prefix(parsed.path)
-    endpoints = BIGDB_PROTO_PORTS
 
-    if parsed.port is not None:
-        # An explicit port was specified — use it directly, derive scheme from port convention
-        matching_endpoint = next((endpoint for endpoint in BIGDB_PROTO_PORTS if endpoint.port_no == parsed.port), None)
-        if matching_endpoint is not None:
-            scheme = matching_endpoint.scheme
-        else:
-            scheme = "http" if parsed.port == 8080 else "https"
-        prefix = path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else "")
-        endpoints = [
-            ApiEndpointConfig(
-                scheme=scheme,
-                port_no=parsed.port,
-                prefix=prefix,
-            )
-        ]
-        path_prefix = ""
-
-    for endpoint in endpoints:
+    for endpoint in BIGDB_PROTO_PORTS:
         prefix = path_prefix or endpoint.prefix
         url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{prefix}"
         try:

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -586,7 +586,11 @@ def _is_valid_probe_response(url: str, response: requests.Response) -> bool:
     content_type, *_ct_params = response.headers.get("Content-Type", "").split(";", maxsplit=1)
     if content_type.lower().strip() == "application/json":
         return True
-    logger.debug("Probe to %s returned 200 but unexpected Content-Type %r; skipping", url, response.headers.get("Content-Type", ""))
+    logger.debug(
+        "Probe to %s returned 200 but unexpected Content-Type %r; skipping",
+        url,
+        response.headers.get("Content-Type", ""),
+    )
     return False
 
 

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -571,6 +571,22 @@ BIGDB_PROTO_PORTS = [
 ]
 
 
+def _is_valid_probe_response(response: requests.Response, validate_path: str) -> bool:
+    """Return True when a probe response confirms the endpoint is really BigDB.
+
+    The default auth health probe is vulnerable to GUI catch-all routes returning
+    HTML with HTTP 200 on older controllers. Only accept that probe when the body
+    is the expected boolean payload.
+    """
+    if response.status_code != 200:
+        return False
+
+    if validate_path == "/api/v1/auth/healthy":
+        return response.text.strip().lower() in {"true", "false"}
+
+    return True
+
+
 def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v1/auth/healthy") -> str:
     """Guess the correct BigDB URL for a given host if not specified completely.
     :param session: requests session to use
@@ -612,7 +628,7 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
         except requests.exceptions.ConnectionError as e:
             logger.debug("Error connecting to %s: %s", url, str(e))
             continue
-        if response.status_code == 200:  # OK
+        if _is_valid_probe_response(response, validate_path):
             return url
         else:
             logger.debug("Could connect to URL %s: %s", url, response)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -1,4 +1,5 @@
 import json
+import ipaddress
 import logging
 import re
 import urllib.parse
@@ -587,6 +588,23 @@ def _is_valid_probe_response(response: requests.Response, validate_path: str) ->
     return True
 
 
+def _normalize_path_prefix(path_prefix: str) -> str:
+    if not path_prefix or path_prefix == "/":
+        return ""
+    if path_prefix.endswith("/"):
+        path_prefix = path_prefix[:-1]
+    return path_prefix if path_prefix.startswith("/") else f"/{path_prefix}"
+
+
+def _format_url_authority(hostname: str) -> str:
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return hostname
+
+    return f"[{hostname}]" if isinstance(address, ipaddress.IPv6Address) else hostname
+
+
 def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v1/auth/healthy") -> str:
     """Guess the correct BigDB URL for a given host if not specified completely.
     :param session: requests session to use
@@ -599,8 +617,11 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
 
     # Parse a URL without a scheme to detect explicit port (host:port) or path prefix (host/prefix)
     parsed = urlparse(f"//{host}")
-    hostname = parsed.hostname or host
-    path_prefix = parsed.path
+    hostname = parsed.hostname
+    if hostname is None:
+        raise ValueError(f"Could not parse host from {host!r}")
+    hostname = _format_url_authority(hostname)
+    path_prefix = _normalize_path_prefix(parsed.path)
     endpoints = BIGDB_PROTO_PORTS
 
     if parsed.port is not None:
@@ -609,7 +630,7 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
         if matching_endpoint is not None:
             scheme = matching_endpoint.scheme
         else:
-            scheme = "https" if parsed.port in (443, 8443) else "http"
+            scheme = "http" if parsed.port == 8080 else "https"
         prefix = path_prefix or (matching_endpoint.prefix if matching_endpoint is not None else "")
         endpoints = [
             ApiEndpointConfig(
@@ -625,7 +646,7 @@ def guess_url(session: requests.Session, host: str, validate_path: str = "/api/v
         url = f"{endpoint.scheme}://{hostname}:{endpoint.port_no}{prefix}"
         try:
             response = session.get(url + validate_path, timeout=2)
-        except requests.exceptions.ConnectionError as e:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             logger.debug("Error connecting to %s: %s", url, str(e))
             continue
         if _is_valid_probe_response(response, validate_path):

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -47,6 +47,29 @@ class TestBigDBClient(unittest.TestCase):
         pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
 
     @responses.activate
+    def test_connect_modern_login_port_443_prefix(self):
+        def _data_cb(req):
+            self.assertEqual(req.headers["Cookie"], "session_cookie=UPhNWlmDN0re8cg9xsqe9QT1QvQTznji")
+            return (200, {}, json.dumps({"state": "ok"}))
+
+        responses.add(responses.GET, "https://127.0.0.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add_callback(
+            responses.POST,
+            "https://127.0.0.1:443/a/api/v1/rpc/controller/core/aaa/session/login",
+            callback=self._login_cb,
+            content_type="application/json",
+        )
+        responses.add_callback(
+            responses.GET,
+            "https://127.0.0.1:443/a/api/v1/data/controller/test",
+            callback=_data_cb,
+            content_type="application/json",
+        )
+
+        client = pybsn.connect("127.0.0.1", "admin", "somepassword")
+        self.assertEqual(client.get("controller/test"), {"state": "ok"})
+
+    @responses.activate
     def test_close_no_auth(self):
         self.client.close()
 

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -52,7 +52,13 @@ class TestBigDBClient(unittest.TestCase):
             self.assertEqual(req.headers["Cookie"], "session_cookie=UPhNWlmDN0re8cg9xsqe9QT1QvQTznji")
             return (200, {}, json.dumps({"state": "ok"}))
 
-        responses.add(responses.GET, "https://127.0.0.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://127.0.0.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
         responses.add_callback(
             responses.POST,
             "https://127.0.0.1:443/a/api/v1/rpc/controller/core/aaa/session/login",

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -1,0 +1,322 @@
+"""Tests for port 443 with /a prefix support
+
+These include:
+1. Port 443 with /a prefix discovery
+2. Fallback behavior when port 443 is unavailable
+3. Prefix is correctly applied only to port 443
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+import responses
+
+import pybsn
+
+
+class TestGuessUrlFallback(unittest.TestCase):
+    """Test the guess_url() function's port discovery and fallback logic."""
+
+    @responses.activate
+    def test_port_443_with_prefix_tried_first(self):
+        """Port 443 with /a prefix should be tried first."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_fallback_to_8443_when_443_unavailable(self):
+        """Should fallback to port 8443 when 443 is not available."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_fallback_to_8080_when_443_and_8443_unavailable(self):
+        """Should fallback to port 8080 when both 443 and 8443 fail."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "http://192.0.2.1:8080")
+        self.assertEqual(len(responses.calls), 3)
+
+    @responses.activate
+    def test_non_200_response_causes_fallback(self):
+        """Non-200 responses should cause fallback to next port."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=404)
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+
+    @responses.activate
+    def test_exception_when_all_ports_fail(self):
+        """Should raise exception when all ports fail."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+
+        session = requests.Session()
+        with self.assertRaises(Exception) as context:
+            pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertIn("Could not find available BigDB service", str(context.exception))
+
+    @responses.activate
+    def test_complete_url_bypasses_discovery(self):
+        """Complete URLs should be returned as-is without port probing."""
+        session = requests.Session()
+
+        url = pybsn.guess_url(session, "https://192.0.2.1:8443")
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 0)
+
+
+class TestPort443PrefixApplication(unittest.TestCase):
+    """Test that /a prefix is correctly applied only to port 443."""
+
+    @responses.activate
+    def test_prefix_applied_to_port_443(self):
+        """The /a prefix should be included in all requests to port 443."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request includes /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertIn("/a/api/v1/data/", data_call.request.url)
+
+    @responses.activate
+    def test_prefix_not_applied_to_port_8443(self):
+        """The /a prefix should NOT be included in requests to port 8443."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request does NOT include /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertNotIn("/a/", data_call.request.url)
+        self.assertEqual(data_call.request.url, "https://192.0.2.1:8443/api/v1/data/controller/core/switch")
+
+    @responses.activate
+    def test_prefix_not_applied_to_port_8080(self):
+        """The /a prefix should NOT be included in requests to port 8080."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/data/controller/core/switch",
+            json=[{"dpid": "00:00:00:00:00:00:00:01"}],
+            status=200,
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+
+        # Verify data request does NOT include /a prefix
+        data_call = [c for c in responses.calls if "/data/" in c.request.url][0]
+        self.assertNotIn("/a/", data_call.request.url)
+        self.assertEqual(data_call.request.url, "http://192.0.2.1:8080/api/v1/data/controller/core/switch")
+
+    @responses.activate
+    def test_all_request_types_include_prefix_on_443(self):
+        """All request types (data, rpc, schema) should include /a prefix on port 443."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/data/controller/core/switch", json=[], status=200)
+        responses.add(
+            responses.POST, "https://192.0.2.1:443/a/api/v1/rpc/controller/test/action", json={"result": "ok"}, status=200
+        )
+        responses.add(
+            responses.GET, "https://192.0.2.1:443/a/api/v1/schema/controller/core/switch", json={"type": "object"}, status=200
+        )
+
+        client = pybsn.connect("192.0.2.1")
+        client.get("controller/core/switch")
+        client.rpc("controller/test/action", {})
+        client.schema("controller/core/switch")
+
+        # Verify all requests include /a prefix
+        for call in responses.calls[1:]:  # Skip the healthy check
+            self.assertIn(
+                "/a/api/v1/",
+                call.request.url,
+                f"Request {call.request.url} should include /a prefix",
+            )
+
+
+class TestSchemalessUrl(unittest.TestCase):
+    """Test handling of schema-less URLs with explicit port or path prefix."""
+
+    @responses.activate
+    def test_explicit_port_uses_https(self):
+        """host:8443 should use https and only probe that port."""
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:8443")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_443_without_prefix_uses_default_prefix(self):
+        """host:443 should use https and the default /a prefix."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:443")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_443_with_prefix_uses_https(self):
+        """host:443/a should use https and only probe that port."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:443/a")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_explicit_port_8080_uses_http(self):
+        """host:8080 should use http and only probe that port."""
+        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:8080")
+
+        self.assertEqual(url, "http://192.0.2.1:8080")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_custom_path_prefix_probes_all_ports(self):
+        """host/custom-prefix should probe all ports with that prefix."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/custom/api/v1/auth/healthy",
+            body=requests.exceptions.ConnectionError("Connection refused"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/custom/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1/custom")
+
+        self.assertEqual(url, "https://192.0.2.1:8443/custom")
+        self.assertEqual(len(responses.calls), 2)
+
+
+class TestFallbackTiming(unittest.TestCase):
+    """Test fallback timeout behavior."""
+
+    def test_timeout_is_2_seconds(self):
+        """Verify the timeout for each port probe is 2 seconds."""
+        session = requests.Session()
+
+        with patch.object(session, "get") as mock_get:
+            mock_get.side_effect = [
+                Mock(status_code=404),
+                Mock(status_code=200),
+            ]
+
+            pybsn.guess_url(session, "192.0.2.1")
+
+            # Each call should have timeout=2
+            for call in mock_get.call_args_list:
+                self.assertEqual(call[1].get("timeout"), 2)
+
+    def test_fallback_order_is_correct(self):
+        """Verify ports are tried in order: 443, 8443, 8080."""
+        session = requests.Session()
+
+        with patch.object(session, "get") as mock_get:
+            mock_get.side_effect = [
+                Mock(status_code=404),  # 443 fails
+                Mock(status_code=404),  # 8443 fails
+                Mock(status_code=200),  # 8080 succeeds
+            ]
+
+            pybsn.guess_url(session, "192.0.2.1")
+
+            # Extract URLs from calls
+            urls = [call[0][0] for call in mock_get.call_args_list]
+
+            self.assertIn("443", urls[0], "First attempt should be port 443")
+            self.assertIn(pybsn.API_PREFIX, urls[0], "Port 443 should include /a prefix")
+            self.assertIn("8443", urls[1], "Second attempt should be port 8443")
+            self.assertNotIn("/a/", urls[1], "Port 8443 should NOT include /a prefix")
+            self.assertIn("8080", urls[2], "Third attempt should be port 8080")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -21,7 +21,13 @@ class TestGuessUrlFallback(unittest.TestCase):
     @responses.activate
     def test_port_443_with_prefix_tried_first(self):
         """Port 443 with /a prefix should be tried first."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -37,7 +43,13 @@ class TestGuessUrlFallback(unittest.TestCase):
             "https://192.0.2.1:443/a/api/v1/auth/healthy",
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -53,7 +65,13 @@ class TestGuessUrlFallback(unittest.TestCase):
             "https://192.0.2.1:443/a/api/v1/auth/healthy",
             body=requests.exceptions.Timeout("Timed out"),
         )
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -74,7 +92,13 @@ class TestGuessUrlFallback(unittest.TestCase):
             "https://192.0.2.1:8443/api/v1/auth/healthy",
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
-        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -86,7 +110,13 @@ class TestGuessUrlFallback(unittest.TestCase):
     def test_non_200_response_causes_fallback(self):
         """Non-200 responses should cause fallback to next port."""
         responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=404)
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -103,7 +133,13 @@ class TestGuessUrlFallback(unittest.TestCase):
             body="<!doctype html><html><body>gui</body></html>",
             content_type="text/html",
         )
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -112,9 +148,15 @@ class TestGuessUrlFallback(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
 
     @responses.activate
-    def test_false_health_response_is_still_accepted(self):
-        """A boolean false health payload still proves the endpoint is BigDB."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="false")
+    def test_json_health_response_is_still_accepted(self):
+        """A JSON health response is accepted regardless of the body content."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="false",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1")
@@ -123,7 +165,7 @@ class TestGuessUrlFallback(unittest.TestCase):
 
     @responses.activate
     def test_custom_validate_path_accepts_any_200_body(self):
-        """Non-default validation paths keep accepting any 200 response body."""
+        """Non-default validation paths accept any JSON response body."""
         responses.add(
             responses.GET,
             "https://192.0.2.1:443/a/api/v1/schema/controller",
@@ -139,6 +181,30 @@ class TestGuessUrlFallback(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
+    def test_custom_validate_path_html_falls_through(self):
+        """Non-default validation paths reject HTML catch-all responses too."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/schema/controller",
+            status=200,
+            body="<html>gui</html>",
+            content_type="text/html",
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/schema/controller",
+            status=200,
+            body='{"schema": "ok"}',
+            content_type="application/json",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1", validate_path="/api/v1/schema/controller")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
     def test_custom_validate_path_non_200_falls_through(self):
         """Non-default validation paths still require HTTP 200."""
         responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/schema/controller", status=404)
@@ -146,8 +212,8 @@ class TestGuessUrlFallback(unittest.TestCase):
             responses.GET,
             "https://192.0.2.1:8443/api/v1/schema/controller",
             status=200,
-            body="<html>ok</html>",
-            content_type="text/html",
+            body='{"schema": "ok"}',
+            content_type="application/json",
         )
 
         session = requests.Session()
@@ -197,7 +263,13 @@ class TestPort443PrefixApplication(unittest.TestCase):
     @responses.activate
     def test_prefix_applied_to_port_443(self):
         """The /a prefix should be included in all requests to port 443."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
         responses.add(
             responses.GET,
             "https://192.0.2.1:443/a/api/v1/data/controller/core/switch",
@@ -220,7 +292,13 @@ class TestPort443PrefixApplication(unittest.TestCase):
             "https://192.0.2.1:443/a/api/v1/auth/healthy",
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
         responses.add(
             responses.GET,
             "https://192.0.2.1:8443/api/v1/data/controller/core/switch",
@@ -249,7 +327,13 @@ class TestPort443PrefixApplication(unittest.TestCase):
             "https://192.0.2.1:8443/api/v1/auth/healthy",
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
-        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
         responses.add(
             responses.GET,
             "http://192.0.2.1:8080/api/v1/data/controller/core/switch",
@@ -268,7 +352,13 @@ class TestPort443PrefixApplication(unittest.TestCase):
     @responses.activate
     def test_all_request_types_include_prefix_on_443(self):
         """All request types (data, rpc, schema) should include /a prefix on port 443."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
         responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/data/controller/core/switch", json=[], status=200)
         responses.add(
             responses.POST, "https://192.0.2.1:443/a/api/v1/rpc/controller/test/action", json={"result": "ok"}, status=200
@@ -304,7 +394,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_explicit_port_uses_https(self):
         """host:8443 should use https and only probe that port."""
-        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1:8443")
@@ -315,7 +411,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_ipv6_without_port_reapplies_brackets(self):
         """Bracketless parsed IPv6 hostnames must be re-bracketed in URLs."""
-        responses.add(responses.GET, "https://[2001:db8::1]:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://[2001:db8::1]:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "[2001:db8::1]")
@@ -326,7 +428,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_ipv6_with_explicit_port_reapplies_brackets(self):
         """IPv6 literals with explicit ports must keep a valid URL authority."""
-        responses.add(responses.GET, "https://[2001:db8::1]:8443/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://[2001:db8::1]:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "[2001:db8::1]:8443")
@@ -337,7 +445,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_explicit_port_443_without_prefix_uses_default_prefix(self):
         """host:443 should use https and the default /a prefix."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1:443")
@@ -348,7 +462,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_explicit_port_443_with_prefix_uses_https(self):
         """host:443/a should use https and only probe that port."""
-        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1:443/a")
@@ -359,7 +479,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_explicit_port_8080_uses_http(self):
         """host:8080 should use http and only probe that port."""
-        responses.add(responses.GET, "http://192.0.2.1:8080/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "http://192.0.2.1:8080/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1:8080")
@@ -392,7 +518,13 @@ class TestSchemalessUrl(unittest.TestCase):
             "https://192.0.2.1:443/custom/api/v1/auth/healthy",
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
-        responses.add(responses.GET, "https://192.0.2.1:8443/custom/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/custom/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "192.0.2.1/custom")
@@ -403,7 +535,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_root_only_trailing_slash_uses_default_prefix_without_double_slash(self):
         """A trailing slash alone should normalize to the default endpoint prefix."""
-        responses.add(responses.GET, "https://controller.example:443/a/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://controller.example:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "controller.example/")
@@ -414,7 +552,13 @@ class TestSchemalessUrl(unittest.TestCase):
     @responses.activate
     def test_custom_path_prefix_trailing_slash_is_normalized(self):
         """A custom trailing slash should not create double-slash API paths."""
-        responses.add(responses.GET, "https://controller.example:443/custom/api/v1/auth/healthy", status=200, body="true")
+        responses.add(
+            responses.GET,
+            "https://controller.example:443/custom/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
 
         session = requests.Session()
         url = pybsn.guess_url(session, "controller.example/custom/")
@@ -433,7 +577,7 @@ class TestFallbackTiming(unittest.TestCase):
         with patch.object(session, "get") as mock_get:
             mock_get.side_effect = [
                 Mock(status_code=404),
-                Mock(status_code=200, text="true"),
+                Mock(status_code=200, text="true", headers={"Content-Type": "application/json"}),
             ]
 
             pybsn.guess_url(session, "192.0.2.1")
@@ -450,7 +594,7 @@ class TestFallbackTiming(unittest.TestCase):
             mock_get.side_effect = [
                 Mock(status_code=404),  # 443 fails
                 Mock(status_code=404),  # 8443 fails
-                Mock(status_code=200, text="true"),  # 8080 succeeds
+                Mock(status_code=200, text="true", headers={"Content-Type": "application/json"}),  # 8080 succeeds
             ]
 
             pybsn.guess_url(session, "192.0.2.1")

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -484,6 +484,23 @@ class TestSchemalessUrl(unittest.TestCase):
 class TestFallbackTiming(unittest.TestCase):
     """Test fallback timeout behavior."""
 
+    def _assert_probe_rejection_log(self, first_response, expected_fragment):
+        session = requests.Session()
+
+        with patch.object(session, "get") as mock_get:
+            mock_get.side_effect = [
+                first_response,
+                Mock(status_code=200, headers={"Content-Type": "application/json"}),
+            ]
+
+            with self.assertLogs("pybsn", level="DEBUG") as logs:
+                pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertTrue(
+            any(expected_fragment in message for message in logs.output),
+            logs.output,
+        )
+
     def test_timeout_is_2_seconds(self):
         """Verify the timeout for each port probe is 2 seconds."""
         session = requests.Session()
@@ -521,6 +538,20 @@ class TestFallbackTiming(unittest.TestCase):
             self.assertIn("8443", urls[1], "Second attempt should be port 8443")
             self.assertNotIn("/a/", urls[1], "Port 8443 should NOT include /a prefix")
             self.assertIn("8080", urls[2], "Third attempt should be port 8080")
+
+    def test_logs_non_200_probe_rejection_reason(self):
+        """Non-200 probe failures should log the rejected status code."""
+        self._assert_probe_rejection_log(
+            Mock(status_code=404, headers={}),
+            "returned status 404; skipping",
+        )
+
+    def test_logs_wrong_content_type_probe_rejection_reason(self):
+        """HTTP 200 HTML responses should log the unexpected content type."""
+        self._assert_probe_rejection_log(
+            Mock(status_code=200, headers={"Content-Type": "text/html"}),
+            "unexpected Content-Type 'text/html'; skipping",
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -46,6 +46,22 @@ class TestGuessUrlFallback(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
 
     @responses.activate
+    def test_fallback_to_8443_when_443_times_out(self):
+        """Should fallback to port 8443 when 443 times out."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            body=requests.exceptions.Timeout("Timed out"),
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
     def test_fallback_to_8080_when_443_and_8443_unavailable(self):
         """Should fallback to port 8080 when both 443 and 8443 fail."""
         responses.add(
@@ -104,6 +120,41 @@ class TestGuessUrlFallback(unittest.TestCase):
         url = pybsn.guess_url(session, "192.0.2.1")
 
         self.assertEqual(url, "https://192.0.2.1:443/a")
+
+    @responses.activate
+    def test_custom_validate_path_accepts_any_200_body(self):
+        """Non-default validation paths keep accepting any 200 response body."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/schema/controller",
+            status=200,
+            body='{"schema": "ok"}',
+            content_type="application/json",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1", validate_path="/api/v1/schema/controller")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_custom_validate_path_non_200_falls_through(self):
+        """Non-default validation paths still require HTTP 200."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/schema/controller", status=404)
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/schema/controller",
+            status=200,
+            body="<html>ok</html>",
+            content_type="text/html",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1", validate_path="/api/v1/schema/controller")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
 
     @responses.activate
     def test_exception_when_all_ports_fail(self):
@@ -243,6 +294,13 @@ class TestPort443PrefixApplication(unittest.TestCase):
 class TestSchemalessUrl(unittest.TestCase):
     """Test handling of schema-less URLs with explicit port or path prefix."""
 
+    def test_invalid_host_raises_parse_error(self):
+        """Malformed scheme-less input should fail instead of probing a raw host string."""
+        session = requests.Session()
+
+        with self.assertRaises(ValueError):
+            pybsn.guess_url(session, "")
+
     @responses.activate
     def test_explicit_port_uses_https(self):
         """host:8443 should use https and only probe that port."""
@@ -252,6 +310,28 @@ class TestSchemalessUrl(unittest.TestCase):
         url = pybsn.guess_url(session, "192.0.2.1:8443")
 
         self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_ipv6_without_port_reapplies_brackets(self):
+        """Bracketless parsed IPv6 hostnames must be re-bracketed in URLs."""
+        responses.add(responses.GET, "https://[2001:db8::1]:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "[2001:db8::1]")
+
+        self.assertEqual(url, "https://[2001:db8::1]:443/a")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_ipv6_with_explicit_port_reapplies_brackets(self):
+        """IPv6 literals with explicit ports must keep a valid URL authority."""
+        responses.add(responses.GET, "https://[2001:db8::1]:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "[2001:db8::1]:8443")
+
+        self.assertEqual(url, "https://[2001:db8::1]:8443")
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
@@ -288,6 +368,23 @@ class TestSchemalessUrl(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
+    def test_explicit_custom_port_uses_https(self):
+        """Unknown explicit ports should default to https."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:9443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1:9443")
+
+        self.assertEqual(url, "https://192.0.2.1:9443")
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
     def test_custom_path_prefix_probes_all_ports(self):
         """host/custom-prefix should probe all ports with that prefix."""
         responses.add(
@@ -302,6 +399,28 @@ class TestSchemalessUrl(unittest.TestCase):
 
         self.assertEqual(url, "https://192.0.2.1:8443/custom")
         self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_root_only_trailing_slash_uses_default_prefix_without_double_slash(self):
+        """A trailing slash alone should normalize to the default endpoint prefix."""
+        responses.add(responses.GET, "https://controller.example:443/a/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "controller.example/")
+
+        self.assertEqual(url, "https://controller.example:443/a")
+        self.assertEqual(responses.calls[0].request.url, "https://controller.example:443/a/api/v1/auth/healthy")
+
+    @responses.activate
+    def test_custom_path_prefix_trailing_slash_is_normalized(self):
+        """A custom trailing slash should not create double-slash API paths."""
+        responses.add(responses.GET, "https://controller.example:443/custom/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "controller.example/custom/")
+
+        self.assertEqual(url, "https://controller.example:443/custom")
+        self.assertEqual(responses.calls[0].request.url, "https://controller.example:443/custom/api/v1/auth/healthy")
 
 
 class TestFallbackTiming(unittest.TestCase):

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -78,6 +78,34 @@ class TestGuessUrlFallback(unittest.TestCase):
         self.assertEqual(url, "https://192.0.2.1:8443")
 
     @responses.activate
+    def test_html_response_on_443_causes_fallback(self):
+        """A GUI HTML catch-all on 443 /a should not be mistaken for BigDB."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="<!doctype html><html><body>gui</body></html>",
+            content_type="text/html",
+        )
+        responses.add(responses.GET, "https://192.0.2.1:8443/api/v1/auth/healthy", status=200, body="true")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_false_health_response_is_still_accepted(self):
+        """A boolean false health payload still proves the endpoint is BigDB."""
+        responses.add(responses.GET, "https://192.0.2.1:443/a/api/v1/auth/healthy", status=200, body="false")
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+
+    @responses.activate
     def test_exception_when_all_ports_fail(self):
         """Should raise exception when all ports fail."""
         responses.add(
@@ -286,7 +314,7 @@ class TestFallbackTiming(unittest.TestCase):
         with patch.object(session, "get") as mock_get:
             mock_get.side_effect = [
                 Mock(status_code=404),
-                Mock(status_code=200),
+                Mock(status_code=200, text="true"),
             ]
 
             pybsn.guess_url(session, "192.0.2.1")
@@ -303,7 +331,7 @@ class TestFallbackTiming(unittest.TestCase):
             mock_get.side_effect = [
                 Mock(status_code=404),  # 443 fails
                 Mock(status_code=404),  # 8443 fails
-                Mock(status_code=200),  # 8080 succeeds
+                Mock(status_code=200, text="true"),  # 8080 succeeds
             ]
 
             pybsn.guess_url(session, "192.0.2.1")

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -164,6 +164,46 @@ class TestGuessUrlFallback(unittest.TestCase):
         self.assertEqual(url, "https://192.0.2.1:443/a")
 
     @responses.activate
+    def test_json_content_type_with_charset_is_accepted(self):
+        """Standard JSON content types with parameters are still accepted."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json; charset=utf-8",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:443/a")
+
+    @responses.activate
+    def test_json_like_content_type_is_rejected(self):
+        """Only the exact JSON media type should be accepted."""
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:443/a/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json-foo",
+        )
+        responses.add(
+            responses.GET,
+            "https://192.0.2.1:8443/api/v1/auth/healthy",
+            status=200,
+            body="true",
+            content_type="application/json",
+        )
+
+        session = requests.Session()
+        url = pybsn.guess_url(session, "192.0.2.1")
+
+        self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
     def test_custom_validate_path_accepts_any_200_body(self):
         """Non-default validation paths accept any JSON response body."""
         responses.add(
@@ -254,6 +294,14 @@ class TestGuessUrlFallback(unittest.TestCase):
 
         url = pybsn.guess_url(session, "https://192.0.2.1:8443")
         self.assertEqual(url, "https://192.0.2.1:8443")
+        self.assertEqual(len(responses.calls), 0)
+
+    def test_complete_url_with_custom_prefix_bypasses_discovery(self):
+        """A fully qualified URL remains explicit even when it carries a custom prefix."""
+        session = requests.Session()
+
+        url = pybsn.guess_url(session, "https://controller.example/custom")
+        self.assertEqual(url, "https://controller.example/custom")
         self.assertEqual(len(responses.calls), 0)
 
 
@@ -382,7 +430,7 @@ class TestPort443PrefixApplication(unittest.TestCase):
 
 
 class TestSchemalessUrl(unittest.TestCase):
-    """Test handling of schema-less URLs with optional path prefixes."""
+    """Test handling of schema-less URLs."""
 
     def test_invalid_host_raises_parse_error(self):
         """Malformed scheme-less input should fail instead of probing a raw host string."""
@@ -425,26 +473,12 @@ class TestSchemalessUrl(unittest.TestCase):
             pybsn.guess_url(session, "[2001:db8::1]:8443")
 
     @responses.activate
-    def test_custom_path_prefix_probes_all_ports(self):
-        """host/custom-prefix should probe all ports with that prefix."""
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:443/custom/api/v1/auth/healthy",
-            body=requests.exceptions.ConnectionError("Connection refused"),
-        )
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:8443/custom/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
+    def test_schemeless_path_prefix_is_rejected(self):
+        """Custom prefixes require a fully qualified URL."""
         session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1/custom")
 
-        self.assertEqual(url, "https://192.0.2.1:8443/custom")
-        self.assertEqual(len(responses.calls), 2)
+        with self.assertRaises(ValueError):
+            pybsn.guess_url(session, "192.0.2.1/custom")
 
     @responses.activate
     def test_root_only_trailing_slash_uses_default_prefix_without_double_slash(self):
@@ -464,21 +498,12 @@ class TestSchemalessUrl(unittest.TestCase):
         self.assertEqual(responses.calls[0].request.url, "https://controller.example:443/a/api/v1/auth/healthy")
 
     @responses.activate
-    def test_custom_path_prefix_trailing_slash_is_normalized(self):
-        """A custom trailing slash should not create double-slash API paths."""
-        responses.add(
-            responses.GET,
-            "https://controller.example:443/custom/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
+    def test_schemeless_path_prefix_with_trailing_slash_is_rejected(self):
+        """Custom prefixes still require a scheme even with a trailing slash."""
         session = requests.Session()
-        url = pybsn.guess_url(session, "controller.example/custom/")
 
-        self.assertEqual(url, "https://controller.example:443/custom")
-        self.assertEqual(responses.calls[0].request.url, "https://controller.example:443/custom/api/v1/auth/healthy")
+        with self.assertRaises(ValueError):
+            pybsn.guess_url(session, "controller.example/custom/")
 
 
 class TestFallbackTiming(unittest.TestCase):

--- a/test/test_port_443_prefix.py
+++ b/test/test_port_443_prefix.py
@@ -382,7 +382,7 @@ class TestPort443PrefixApplication(unittest.TestCase):
 
 
 class TestSchemalessUrl(unittest.TestCase):
-    """Test handling of schema-less URLs with explicit port or path prefix."""
+    """Test handling of schema-less URLs with optional path prefixes."""
 
     def test_invalid_host_raises_parse_error(self):
         """Malformed scheme-less input should fail instead of probing a raw host string."""
@@ -392,21 +392,12 @@ class TestSchemalessUrl(unittest.TestCase):
             pybsn.guess_url(session, "")
 
     @responses.activate
-    def test_explicit_port_uses_https(self):
-        """host:8443 should use https and only probe that port."""
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:8443/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
+    def test_schemeless_explicit_port_is_rejected(self):
+        """Custom ports still require a fully qualified URL."""
         session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1:8443")
 
-        self.assertEqual(url, "https://192.0.2.1:8443")
-        self.assertEqual(len(responses.calls), 1)
+        with self.assertRaises(ValueError):
+            pybsn.guess_url(session, "192.0.2.1:8443")
 
     @responses.activate
     def test_ipv6_without_port_reapplies_brackets(self):
@@ -426,89 +417,12 @@ class TestSchemalessUrl(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
-    def test_ipv6_with_explicit_port_reapplies_brackets(self):
-        """IPv6 literals with explicit ports must keep a valid URL authority."""
-        responses.add(
-            responses.GET,
-            "https://[2001:db8::1]:8443/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
+    def test_schemeless_ipv6_with_explicit_port_is_rejected(self):
+        """Bracketed IPv6 literals still require a scheme when a port is supplied."""
         session = requests.Session()
-        url = pybsn.guess_url(session, "[2001:db8::1]:8443")
 
-        self.assertEqual(url, "https://[2001:db8::1]:8443")
-        self.assertEqual(len(responses.calls), 1)
-
-    @responses.activate
-    def test_explicit_port_443_without_prefix_uses_default_prefix(self):
-        """host:443 should use https and the default /a prefix."""
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:443/a/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
-        session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1:443")
-
-        self.assertEqual(url, "https://192.0.2.1:443/a")
-        self.assertEqual(len(responses.calls), 1)
-
-    @responses.activate
-    def test_explicit_port_443_with_prefix_uses_https(self):
-        """host:443/a should use https and only probe that port."""
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:443/a/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
-        session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1:443/a")
-
-        self.assertEqual(url, "https://192.0.2.1:443/a")
-        self.assertEqual(len(responses.calls), 1)
-
-    @responses.activate
-    def test_explicit_port_8080_uses_http(self):
-        """host:8080 should use http and only probe that port."""
-        responses.add(
-            responses.GET,
-            "http://192.0.2.1:8080/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
-        session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1:8080")
-
-        self.assertEqual(url, "http://192.0.2.1:8080")
-        self.assertEqual(len(responses.calls), 1)
-
-    @responses.activate
-    def test_explicit_custom_port_uses_https(self):
-        """Unknown explicit ports should default to https."""
-        responses.add(
-            responses.GET,
-            "https://192.0.2.1:9443/api/v1/auth/healthy",
-            status=200,
-            body="true",
-            content_type="application/json",
-        )
-
-        session = requests.Session()
-        url = pybsn.guess_url(session, "192.0.2.1:9443")
-
-        self.assertEqual(url, "https://192.0.2.1:9443")
-        self.assertEqual(len(responses.calls), 1)
+        with self.assertRaises(ValueError):
+            pybsn.guess_url(session, "[2001:db8::1]:8443")
 
     @responses.activate
     def test_custom_path_prefix_probes_all_ports(self):


### PR DESCRIPTION
Health check on older controllers can return status 200 with port 443 and /a prefix even though they
are not suported

Here's a curl request run on an older 8.10.x DMF controller with /a and port 443:
```
bhattack@bhattaRFXCQ7m ~ % curl -sk -D - https://10.243.254.58:443/a/api/v1/auth/healthy
HTTP/2 200 
server: nginx/1.20.1
date: Sun, 26 Jul 2026 21:25:24 GMT
content-type: text/html
content-length: 1682
last-modified: Sun, 26 Jul 2026 12:31:15 GMT
etag: "6a65fe13-692"
content-security-policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:
cache-control: public, max-age=604800
strict-transport-security: max-age=31536000
accept-ranges: bytes

<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"><link rel="apple-touch-icon" sizes="180x180" href="/favicons/dmf/apple-touch-icon.png"><link rel="icon" type="image/png" sizes="32x32" href="/favicons/dmf/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicons/dmf/favicon-16x16.png"><link rel="manifest" href="/favicons/dmf/site.webmanifest"><link rel="mask-icon" href="/favicons/dmf/safari-pinned-tab.svg" color="#5bbad5"><link rel="shortcut icon" href="/favicons/dmf/favicon.ico"><meta name="msapplication-TileColor" content="#da532c"><meta name="msapplication-config" content="/favicons/dmf/browserconfig.xml"><meta name="theme-color" content="#000000"><script>const global = globalThis;</script><script type="module" crossorigin src="/ui-assets/index-DqKzWq2q.js"></script><link rel="modulepreload" crossorigin href="/ui-assets/antd-CGdjyTOk.js"><link rel="modulepreload" crossorigin href="/ui-assets/@arista/react-components-mCWPzMqs.js"><link rel="modulepreload" crossorigin href="/ui-assets/@arista/big-components-C018Nt5g.js"><link rel="modulepreload" crossorigin href="/ui-assets/recharts-3el1gYDM.js"><link rel="modulepreload" crossorigin href="/ui-assets/react-flow-renderer-CtDox3TI.js"><link rel="stylesheet" crossorigin href="/ui-assets/@arista/big-components-CuCGYpG2.css"><link rel="stylesheet" crossorigin href="/ui-assets/index-BdeNc5Xk.css"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div></body></html>% 
```

As seen above, it return 200 but the output is unexpected as /a and port 443 is not supported here but it returns a GUI/nginx catch-all HTML page

The right url returns the following :
```
bhattack@bhattaRFXCQ7m ~ % curl -sk -D - https://10.243.254.58:/api/v1/auth/healthy 
HTTP/2 200 
server: nginx/1.20.1
date: Sun, 26 Jul 2026 21:36:13 GMT
content-type: application/json
accept-ranges: bytes
vary: Accept-Charset, Accept-Encoding, Accept-Language, Accept
content-security-policy: frame-ancestors 'none'; default-src 'none';

true%  
```
So, to differentiate between the 2, adding a new check here that checks if content-type is application/json in which case its a valid response, otherwise not
Added the previously reverted pybsn PR in the first commit of this PR as well

PartialFixes: BUG1413418