### PR TITLE
BUG1925390 Fix IPv6 session cookie matching

### DIFF
--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -5,7 +5,6 @@ import urllib.parse
 import warnings
 from string import Template
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urlparse
 
 import requests
 import urllib3.util
@@ -606,9 +605,7 @@ def _attempt_login(
 
     # If we reach here, status is 2xx (typically 200 for login endpoint)
     json_ = response.json()
-    session_cookie = requests.cookies.create_cookie(
-        name="session_cookie", value=json_["session-cookie"], domain=urlparse(url).hostname, path="/api"  # type: ignore[arg-type]
-    )
+    session_cookie = requests.cookies.create_cookie(name="session_cookie", value=json_["session-cookie"], path="/api")
     session.cookies.set_cookie(session_cookie)
     return url
 

--- a/test/test_timeout_connect.py
+++ b/test/test_timeout_connect.py
@@ -73,3 +73,18 @@ class TestTimeoutConnect(unittest.TestCase):
             mock_send.side_effect = iter([first_response])
             pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword", timeout=timeout)
             self._assertAllCallsTimeoutValue(timeout, mock_send)
+
+    def test_attempt_login_cookie_matches_ipv4_and_ipv6_urls(self):
+        for url in ("http://127.0.0.1:8080", "https://[fdfd::1]:8443"):
+            with self.subTest(url=url):
+                session = requests.Session()
+                response = requests.Response()
+                response.status_code = 200
+                response.json = lambda: {"session-cookie": "some_token"}
+
+                with patch.object(pybsn, "logged_request", return_value=response):
+                    pybsn._attempt_login(session, url, "admin", "somepassword")
+
+                request = requests.Request("GET", url + "/api/v1/data/controller/test")
+                prepared_request = session.prepare_request(request)
+                self.assertEqual(prepared_request.headers["Cookie"], "session_cookie=some_token")


### PR DESCRIPTION
Login scoped the session cookie to urlparse(url).hostname. For IPv6 literal URLs, urlparse strips the brackets from the hostname, while requests matches cookies against the bracketed request authority. The mismatch caused the login cookie to be stored but not sent on later API requests, resulting in 401 responses after a successful login.

Create the login cookie without an explicit domain so the dedicated requests.Session can send it for both IPv4 and IPv6 hosts. Add a regression test that prepares requests for IPv4 and bracketed IPv6 URLs and verifies the session cookie is attached.

Fixes: BUG1925390